### PR TITLE
Use card layout for WebAuthn credentials

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -568,3 +568,7 @@ html[lang|="ko"] i {
 .webauthn-credentials table.table > tbody > tr > td {
   vertical-align: middle;
 }
+
+.webauthn-credentials .webauthn-credential-card {
+  margin-bottom: 1em;
+}

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -565,24 +565,24 @@ html[lang|="ko"] i {
     user-select: all;
 }
 
-.webauthn-credentials {
+.two-column-flexbox {
   align-items: flex-start;
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  column-gap: 1em; /* row-gap emulated by .webauthn-credential-card margin-bottom to fallback gracefully in browsers without Flexbox */
+  column-gap: 1em; /* row-gap emulated by self > * margin-bottom to fallback gracefully in browsers without Flexbox */
   justify-content: space-between;
 }
 
-.webauthn-credentials .webauthn-credential-card {
+.two-column-flexbox > * {
   flex-grow: 1;
   flex-shrink: 0;
-  min-width: 40%; /* Limit to two cards per row */
+  min-width: 40%; /* Limit to two items per row */
   margin-bottom: 1em;
 }
 
 @media (max-width: 768px) {
-  .webauthn-credentials .webauthn-credential-card {
-    min-width: 90%; /* Limit to one card per row on narrow screens */
+  .two-column-flexbox > * {
+    min-width: 90%; /* Limit to one item per row on narrow screens */
   }
 }

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -565,6 +565,24 @@ html[lang|="ko"] i {
     user-select: all;
 }
 
+.webauthn-credentials {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  column-gap: 1em; /* row-gap emulated by .webauthn-credential-card margin-bottom to fallback gracefully in browsers without Flexbox */
+  justify-content: space-between;
+}
+
 .webauthn-credentials .webauthn-credential-card {
+  flex-grow: 1;
+  flex-shrink: 0;
+  min-width: 40%; /* Limit to two cards per row */
   margin-bottom: 1em;
+}
+
+@media (max-width: 768px) {
+  .webauthn-credentials .webauthn-credential-card {
+    min-width: 90%; /* Limit to one card per row on narrow screens */
+  }
 }

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -565,10 +565,6 @@ html[lang|="ko"] i {
     user-select: all;
 }
 
-.webauthn-credentials table.table > tbody > tr > td {
-  vertical-align: middle;
-}
-
 .webauthn-credentials .webauthn-credential-card {
   margin-bottom: 1em;
 }

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -567,18 +567,18 @@ html[lang|="ko"] i {
 
 .two-column-flexbox {
   align-items: flex-start;
+  column-gap: 1em; /* row-gap emulated by self > * margin-bottom to fallback gracefully in browsers without Flexbox */
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  column-gap: 1em; /* row-gap emulated by self > * margin-bottom to fallback gracefully in browsers without Flexbox */
   justify-content: space-between;
 }
 
 .two-column-flexbox > * {
   flex-grow: 1;
   flex-shrink: 0;
-  min-width: 40%; /* Limit to two items per row */
   margin-bottom: 1em;
+  min-width: 40%; /* Limit to two items per row */
 }
 
 @media (max-width: 768px) {

--- a/gui/default/assets/lang/lang-en.json
+++ b/gui/default/assets/lang/lang-en.json
@@ -80,6 +80,7 @@
     "Copied!": "Copied!",
     "Copy": "Copy",
     "Copy failed! Try to select and copy manually.": "Copy failed! Try to select and copy manually.",
+    "Created: {%createTime%}": "Created: {{createTime}}",
     "Current domain does not match WebAuthn configuration.": "Current domain does not match WebAuthn configuration.",
     "Currently Shared With Devices": "Currently Shared With Devices",
     "Custom Range": "Custom Range",
@@ -231,6 +232,7 @@
     "Last Month": "Last Month",
     "Last Scan": "Last Scan",
     "Last seen": "Last seen",
+    "Last used: {%lastUseTime%}": "Last used: {{lastUseTime}}",
     "Latest Change": "Latest Change",
     "Learn more": "Learn more",
     "Learn more at {%url%}": "Learn more at {{url}}",
@@ -343,6 +345,7 @@
     "Remove Folder": "Remove Folder",
     "Rename": "Rename",
     "Required identifier for the folder. Must be the same on all cluster devices.": "Required identifier for the folder. Must be the same on all cluster devices.",
+    "Requires 2FA": "Requires 2FA",
     "Rescan": "Rescan",
     "Rescan All": "Rescan All",
     "Rescans": "Rescans",
@@ -578,6 +581,11 @@
                     "lastUseTime": "Last used",
                     "name": "Name",
                     "require2fa": "2FA"
+                }
+            },
+            "ineligibleCredentials": {
+                "label": {
+                    "rpId": "RP ID:"
                 }
             }
         }

--- a/gui/default/assets/lang/lang-en.json
+++ b/gui/default/assets/lang/lang-en.json
@@ -322,7 +322,6 @@
     "QUIC LAN": "QUIC LAN",
     "QUIC WAN": "QUIC WAN",
     "Quick guide to supported patterns": "Quick guide to supported patterns",
-    "RP ID": "RP ID",
     "Random": "Random",
     "Receive Encrypted": "Receive Encrypted",
     "Receive Only": "Receive Only",
@@ -575,14 +574,6 @@
     "seconds": "seconds",
     "settings": {
         "webauthn": {
-            "credentials": {
-                "columnHeading": {
-                    "createTime": "Created",
-                    "lastUseTime": "Last used",
-                    "name": "Name",
-                    "require2fa": "2FA"
-                }
-            },
             "ineligibleCredentials": {
                 "label": {
                     "rpId": "RP ID:"

--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -163,70 +163,128 @@
           <!-- WebAuthn settings -->
           <div class="form-group">
 
-            <!-- WebAuthn credentials -->
-            <label translate>WebAuthn Credentials (Passkeys)</label>
-            <a href="{{docsURL('users/webauthn')}}" target="_blank">
-              <span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span>
-            </a>
-            <div class="table-responsive webauthn-credentials">
-              <table class="table-striped table">
-                <thead>
-                  <tr>
-                    <th><label translate="settings.webauthn.credentials.columnHeading.name">Name</label></th>
-                    <th><label translate="settings.webauthn.credentials.columnHeading.createTime">Created</label></th>
-                    <th><label translate="settings.webauthn.credentials.columnHeading.lastUseTime">Last used</label></th>
-                    <th>
-                      <label>
-                        <span translate="settings.webauthn.credentials.columnHeading.require2fa">2FA</span>
+            <!-- WebAuthn credentials: >xs devices -->
+            <div class="webauthn-credentials hidden-xs">
+              <label translate>WebAuthn Credentials (Passkeys)</label>
+              <a href="{{docsURL('users/webauthn')}}" target="_blank">
+                <span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span>
+              </a>
+              <div class="table-responsive">
+                <table class="table-striped table">
+                  <thead>
+                    <tr>
+                      <th><label translate="settings.webauthn.credentials.columnHeading.name">Name</label></th>
+                      <th><label translate="settings.webauthn.credentials.columnHeading.createTime">Created</label></th>
+                      <th><label translate="settings.webauthn.credentials.columnHeading.lastUseTime">Last used</label></th>
+                      <th>
+                        <label>
+                          <span translate="settings.webauthn.credentials.columnHeading.require2fa">2FA</span>
+                          <a href="{{docsURL('users/webauthn#webauthn-require2fa')}}">
+                            <span class="fa fa-question-circle" title="Open help: 2FA setting for WebAuthn credentials" />
+                          </a>
+                        </label>
+                      </th>
+                      <th colspan="1000"><label translate>Actions</label></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr ng-repeat="cred in tmpGUI.webauthnState.credentials | filter:{rpId: tmpGUI.webauthnRpId}:true">
+                      <td ng-if="!webauthn.editingCredentialIds[cred.id]" class="no-overflow-ellipse stretch">
+                        {{ cred.nickname || (cred.id | limitTo: 20) }}
+                      </td>
+                      <td ng-if="webauthn.editingCredentialIds[cred.id]" class="no-overflow-ellipse stretch">
+                        <input class="form-control" type="text" ng-model="cred.nickname" placeholder="{{ cred.id }}" />
+                      </td>
+
+                      <td class="small-data" title="{{cred.createTime | date:'yyyy-MM-dd HH:mm:ss'}}">
+                        {{cred.createTime | date:'yyyy-MM-dd'}}
+                      </td>
+                      <td class="small-data" title="{{ webauthn.state.credentials[cred.id].lastUseTime | date:'yyyy-MM-dd HH:mm:ss' }}">
+                        {{ webauthn.state.credentials[cred.id].lastUseTime | date:'yyyy-MM-dd' }}
+                      </td>
+
+                      <td class="small-data text-center">
+                        <input type="checkbox" ng-model="cred.requireUv" />
+                      </td>
+                      <td class="small-data button-cell">
+                        <button type="button" class="btn btn-link btn-sm" ng-click="webauthn.editingCredentialIds[cred.id] = true" ng-disabled="webauthn.editingCredentialIds[cred.id]">
+                          <span class="fas fa-edit"></span>&nbsp;<span translate>Rename</span>
+                        </button>
+                      </td>
+                      <td class="small-data button-cell">
+                        <button type="button" class="btn btn-link btn-sm" ng-click="deleteWebauthnCredential(cred)">
+                          <span class="fas fa-trash"></span>&nbsp;<span translate>Delete</span>
+                        </button>
+                      </td>
+                    </tr>
+                  </tbody>
+                  <tfoot>
+                    <tr>
+                      <td colspan="1000">
+                        <button type="button" class="btn btn-link btn-sm" ng-click="registerWebauthnCredential()" ng-disabled="!webauthnReady()">
+                          <span class="fas fa-plus"></span>&nbsp;<span translate>Add passkey</span>
+                        </button>
+                      </td>
+                    </tr>
+                  </tfoot>
+                </table>
+              </div>
+            </div>
+
+            <div class="visible-xs-block">
+              <!-- WebAuthn credentials: xs devices -->
+              <label translate>WebAuthn Credentials (Passkeys)</label>
+              <a href="{{docsURL('users/webauthn')}}" target="_blank">
+                <span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span>
+              </a>
+              <div class="webauthn-credentials">
+                <div class="webauthn-credential-card panel panel-default" ng-repeat="cred in tmpGUI.webauthnState.credentials | filter:{rpId: tmpGUI.webauthnRpId}:true">
+                  <div class="panel-heading" ng-if="!webauthn.editingCredentialIds[cred.id]">
+                    {{ cred.nickname || (cred.id | limitTo: 20) }}
+                  </div>
+                  <div class="panel-heading" ng-if="webauthn.editingCredentialIds[cred.id]">
+                    <input class="form-control" type="text" ng-model="cred.nickname" placeholder="{{ cred.id }}" />
+                  </div>
+
+                  <div class="panel-body">
+                    <div class="row">
+                      <div class="col-md-12">
+                        <label for="webauthn-credential-2fa-{{cred.id}}" translate>Requires 2FA</label>
+                        <input type="checkbox" ng-model="cred.requireUv" id="webauthn-credential-2fa-{{cred.id}}" />
                         <a href="{{docsURL('users/webauthn#webauthn-require2fa')}}">
                           <span class="fa fa-question-circle" title="Open help: 2FA setting for WebAuthn credentials" />
                         </a>
-                      </label>
-                    </th>
-                    <th colspan="1000"><label translate>Actions</label></th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr ng-repeat="cred in tmpGUI.webauthnState.credentials | filter:{rpId: tmpGUI.webauthnRpId}:true">
-                    <td ng-if="!webauthn.editingCredentialIds[cred.id]" class="no-overflow-ellipse stretch">
-                      {{ cred.nickname || (cred.id | limitTo: 20) }}
-                    </td>
-                    <td ng-if="webauthn.editingCredentialIds[cred.id]" class="no-overflow-ellipse stretch">
-                      <input class="form-control" type="text" ng-model="cred.nickname" placeholder="{{ cred.id }}" />
-                    </td>
+                      </div>
+                    </div>
 
-                    <td class="small-data" title="{{cred.createTime | date:'yyyy-MM-dd HH:mm:ss'}}">
-                      {{cred.createTime | date:'yyyy-MM-dd'}}
-                    </td>
-                    <td class="small-data" title="{{ webauthn.state.credentials[cred.id].lastUseTime | date:'yyyy-MM-dd HH:mm:ss' }}">
-                      {{ webauthn.state.credentials[cred.id].lastUseTime | date:'yyyy-MM-dd' }}
-                    </td>
+                    <div class="row">
+                      <div class="col-md-12"translate translate-value-create-time="{{cred.createTime | date:'yyyy-MM-dd'}}">Created: {%createTime%}</div>
+                    </div>
+                    <div class="row">
+                      <div class="col-md-12" translate translate-value-last-use-time="{{ webauthn.state.credentials[cred.id].lastUseTime | date:'yyyy-MM-dd HH:mm:ss' }}">Last used: {%lastUseTime%}</div>
+                    </div>
 
-                    <td class="small-data text-center">
-                      <input type="checkbox" ng-model="cred.requireUv" />
-                    </td>
-                    <td class="small-data button-cell">
-                      <button type="button" class="btn btn-link btn-sm" ng-click="webauthn.editingCredentialIds[cred.id] = true" ng-disabled="webauthn.editingCredentialIds[cred.id]">
-                        <span class="fas fa-edit"></span>&nbsp;<span translate>Rename</span>
-                      </button>
-                    </td>
-                    <td class="small-data button-cell">
-                      <button type="button" class="btn btn-link btn-sm" ng-click="deleteWebauthnCredential(cred)">
-                        <span class="fas fa-trash"></span>&nbsp;<span translate>Delete</span>
-                      </button>
-                    </td>
-                  </tr>
-                </tbody>
-                <tfoot>
-                  <tr>
-                    <td colspan="1000">
-                      <button type="button" class="btn btn-link btn-sm" ng-click="registerWebauthnCredential()" ng-disabled="!webauthnReady()">
-                        <span class="fas fa-plus"></span>&nbsp;<span translate>Add passkey</span>
-                      </button>
-                    </td>
-                  </tr>
-                </tfoot>
-              </table>
+                    <div class="row">
+                      <div class="col-md-12">
+                        <button type="button" class="btn btn-link btn-sm" ng-click="webauthn.editingCredentialIds[cred.id] = true" ng-disabled="webauthn.editingCredentialIds[cred.id]">
+                          <span class="fas fa-edit"></span>&nbsp;<span translate>Rename</span>
+                        </button>
+                        <button type="button" class="btn btn-link btn-sm" ng-click="deleteWebauthnCredential(cred)">
+                          <span class="fas fa-trash"></span>&nbsp;<span translate>Delete</span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="webauthn-credential-card panel">
+                  <div class="panel-body text-center">
+                    <button type="button" class="btn btn-link btn-sm" ng-click="registerWebauthnCredential()" ng-disabled="!webauthnReady()">
+                      <span class="fas fa-plus"></span>&nbsp;<span translate>Add passkey</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
             </div>
 
             <p class="text-info" ng-if="isLocationInsecure()" translate>WebAuthn requires HTTPS on non-localhost domains.</p>
@@ -258,10 +316,11 @@
               <button ng-if="tmpGUI && !settingsModified()" type="button" class="btn btn-primary" ng-click="reloadSettingsAtWebauthnAddress(false)" translate translate-value-address="{{ getWebauthnOrigin() }}">Reload page at {%address%}</button>
             </p>
 
-            <div ng-repeat="_ in tmpGUI.webauthnState.credentials | filter:{rpId: '!'+tmpGUI.webauthnRpId}:true | limitTo:1">
+            <!-- Ineligible WebAuthn credentials: >xs devices -->
+            <div class="webauthn-credentials hidden-xs" ng-repeat="_ in tmpGUI.webauthnState.credentials | filter:{rpId: '!'+tmpGUI.webauthnRpId}:true | limitTo:1">
               <label translate>Ineligible WebAuthn Credentials (Passkeys)</label>
               <p translate>The credentials below were created with a different setting of "Webauthn Rp Id" in advanced settings. They cannot be used without restoring this setting to the value shown as "RP ID" below. Note that doing so would make any credentials above ineligible instead.</p>
-              <div class="table-responsive webauthn-credentials">
+              <div class="table-responsive">
                 <table class="table-striped table">
                   <thead>
                     <tr>
@@ -301,6 +360,42 @@
                     </tr>
                   </tbody>
                 </table>
+              </div>
+            </div>
+
+            <!-- Ineligible WebAuthn credentials: xs devices -->
+            <div class="visible-xs-block" ng-repeat="_ in tmpGUI.webauthnState.credentials | filter:{rpId: '!'+tmpGUI.webauthnRpId}:true | limitTo:1">
+              <label translate>Ineligible WebAuthn Credentials (Passkeys)</label>
+              <p translate>The credentials below were created with a different setting of "Webauthn Rp Id" in advanced settings. They cannot be used without restoring this setting to the value shown as "RP ID" below. Note that doing so would make any credentials above ineligible instead.</p>
+              <div class="webauthn-credentials">
+                <div class="webauthn-credential-card panel panel-default" ng-repeat="cred in tmpGUI.webauthnState.credentials | filter:{rpId: '!'+tmpGUI.webauthnRpId}:true">
+                  <div class="panel-heading">
+                    <span class="text-warning">
+                      <span class="fas fa-exclamation-triangle"></span>
+                      {{ cred.nickname || (cred.id | limitTo: 20) }}
+                    </span>
+                  </div>
+
+                  <div class="panel-body">
+                    <div class="row">
+                      <div class="col-md-12">
+                        <span translate="settings.webauthn.ineligibleCredentials.label.rpId">RP ID:</span>
+                        <span class="text-monospace">{{ cred.rpId }}</span>
+                      </div>
+                    </div>
+                    <div class="row">
+                      <div class="col-md-12"translate translate-value-create-time="{{cred.createTime | date:'yyyy-MM-dd'}}">Created: {%createTime%}</div>
+                    </div>
+
+                    <div class="row">
+                      <div class="col-md-12">
+                        <button type="button" class="btn btn-link btn-sm" ng-click="deleteWebauthnCredential(cred)">
+                          <span class="fas fa-trash"></span>&nbsp;<span translate>Delete</span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -163,126 +163,56 @@
           <!-- WebAuthn settings -->
           <div class="form-group">
 
-            <!-- WebAuthn credentials: >xs devices -->
-            <div class="webauthn-credentials hidden-xs">
-              <label translate>WebAuthn Credentials (Passkeys)</label>
-              <a href="{{docsURL('users/webauthn')}}" target="_blank">
-                <span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span>
-              </a>
-              <div class="table-responsive">
-                <table class="table-striped table">
-                  <thead>
-                    <tr>
-                      <th><label translate="settings.webauthn.credentials.columnHeading.name">Name</label></th>
-                      <th><label translate="settings.webauthn.credentials.columnHeading.createTime">Created</label></th>
-                      <th><label translate="settings.webauthn.credentials.columnHeading.lastUseTime">Last used</label></th>
-                      <th>
-                        <label>
-                          <span translate="settings.webauthn.credentials.columnHeading.require2fa">2FA</span>
-                          <a href="{{docsURL('users/webauthn#webauthn-require2fa')}}">
-                            <span class="fa fa-question-circle" title="Open help: 2FA setting for WebAuthn credentials" />
-                          </a>
-                        </label>
-                      </th>
-                      <th colspan="1000"><label translate>Actions</label></th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr ng-repeat="cred in tmpGUI.webauthnState.credentials | filter:{rpId: tmpGUI.webauthnRpId}:true">
-                      <td ng-if="!webauthn.editingCredentialIds[cred.id]" class="no-overflow-ellipse stretch">
-                        {{ cred.nickname || (cred.id | limitTo: 20) }}
-                      </td>
-                      <td ng-if="webauthn.editingCredentialIds[cred.id]" class="no-overflow-ellipse stretch">
-                        <input class="form-control" type="text" ng-model="cred.nickname" placeholder="{{ cred.id }}" />
-                      </td>
+            <!-- WebAuthn credentials -->
+            <label translate>WebAuthn Credentials (Passkeys)</label>
+            <a href="{{docsURL('users/webauthn')}}" target="_blank">
+              <span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span>
+            </a>
+            <div class="webauthn-credentials">
+              <div class="webauthn-credential-card panel panel-default" ng-repeat="cred in tmpGUI.webauthnState.credentials | filter:{rpId: tmpGUI.webauthnRpId}:true">
+                <div class="panel-heading" ng-if="!webauthn.editingCredentialIds[cred.id]">
+                  {{ cred.nickname || (cred.id | limitTo: 20) }}
+                </div>
+                <div class="panel-heading" ng-if="webauthn.editingCredentialIds[cred.id]">
+                  <input class="form-control" type="text" ng-model="cred.nickname" placeholder="{{ cred.id }}" />
+                </div>
 
-                      <td class="small-data" title="{{cred.createTime | date:'yyyy-MM-dd HH:mm:ss'}}">
-                        {{cred.createTime | date:'yyyy-MM-dd'}}
-                      </td>
-                      <td class="small-data" title="{{ webauthn.state.credentials[cred.id].lastUseTime | date:'yyyy-MM-dd HH:mm:ss' }}">
-                        {{ webauthn.state.credentials[cred.id].lastUseTime | date:'yyyy-MM-dd' }}
-                      </td>
-
-                      <td class="small-data text-center">
-                        <input type="checkbox" ng-model="cred.requireUv" />
-                      </td>
-                      <td class="small-data button-cell">
-                        <button type="button" class="btn btn-link btn-sm" ng-click="webauthn.editingCredentialIds[cred.id] = true" ng-disabled="webauthn.editingCredentialIds[cred.id]">
-                          <span class="fas fa-edit"></span>&nbsp;<span translate>Rename</span>
-                        </button>
-                      </td>
-                      <td class="small-data button-cell">
-                        <button type="button" class="btn btn-link btn-sm" ng-click="deleteWebauthnCredential(cred)">
-                          <span class="fas fa-trash"></span>&nbsp;<span translate>Delete</span>
-                        </button>
-                      </td>
-                    </tr>
-                  </tbody>
-                  <tfoot>
-                    <tr>
-                      <td colspan="1000">
-                        <button type="button" class="btn btn-link btn-sm" ng-click="registerWebauthnCredential()" ng-disabled="!webauthnReady()">
-                          <span class="fas fa-plus"></span>&nbsp;<span translate>Add passkey</span>
-                        </button>
-                      </td>
-                    </tr>
-                  </tfoot>
-                </table>
-              </div>
-            </div>
-
-            <div class="visible-xs-block">
-              <!-- WebAuthn credentials: xs devices -->
-              <label translate>WebAuthn Credentials (Passkeys)</label>
-              <a href="{{docsURL('users/webauthn')}}" target="_blank">
-                <span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span>
-              </a>
-              <div class="webauthn-credentials">
-                <div class="webauthn-credential-card panel panel-default" ng-repeat="cred in tmpGUI.webauthnState.credentials | filter:{rpId: tmpGUI.webauthnRpId}:true">
-                  <div class="panel-heading" ng-if="!webauthn.editingCredentialIds[cred.id]">
-                    {{ cred.nickname || (cred.id | limitTo: 20) }}
-                  </div>
-                  <div class="panel-heading" ng-if="webauthn.editingCredentialIds[cred.id]">
-                    <input class="form-control" type="text" ng-model="cred.nickname" placeholder="{{ cred.id }}" />
+                <div class="panel-body">
+                  <div class="row">
+                    <div class="col-md-12">
+                      <label for="webauthn-credential-2fa-{{cred.id}}" translate>Requires 2FA</label>
+                      <input type="checkbox" ng-model="cred.requireUv" id="webauthn-credential-2fa-{{cred.id}}" />
+                      <a href="{{docsURL('users/webauthn#webauthn-require2fa')}}">
+                        <span class="fa fa-question-circle" title="Open help: 2FA setting for WebAuthn credentials" />
+                      </a>
+                    </div>
                   </div>
 
-                  <div class="panel-body">
-                    <div class="row">
-                      <div class="col-md-12">
-                        <label for="webauthn-credential-2fa-{{cred.id}}" translate>Requires 2FA</label>
-                        <input type="checkbox" ng-model="cred.requireUv" id="webauthn-credential-2fa-{{cred.id}}" />
-                        <a href="{{docsURL('users/webauthn#webauthn-require2fa')}}">
-                          <span class="fa fa-question-circle" title="Open help: 2FA setting for WebAuthn credentials" />
-                        </a>
-                      </div>
-                    </div>
+                  <div class="row">
+                    <div class="col-md-12"translate translate-value-create-time="{{cred.createTime | date:'yyyy-MM-dd'}}">Created: {%createTime%}</div>
+                  </div>
+                  <div class="row">
+                    <div class="col-md-12" translate translate-value-last-use-time="{{ webauthn.state.credentials[cred.id].lastUseTime | date:'yyyy-MM-dd HH:mm:ss' }}">Last used: {%lastUseTime%}</div>
+                  </div>
 
-                    <div class="row">
-                      <div class="col-md-12"translate translate-value-create-time="{{cred.createTime | date:'yyyy-MM-dd'}}">Created: {%createTime%}</div>
-                    </div>
-                    <div class="row">
-                      <div class="col-md-12" translate translate-value-last-use-time="{{ webauthn.state.credentials[cred.id].lastUseTime | date:'yyyy-MM-dd HH:mm:ss' }}">Last used: {%lastUseTime%}</div>
-                    </div>
-
-                    <div class="row">
-                      <div class="col-md-12">
-                        <button type="button" class="btn btn-link btn-sm" ng-click="webauthn.editingCredentialIds[cred.id] = true" ng-disabled="webauthn.editingCredentialIds[cred.id]">
-                          <span class="fas fa-edit"></span>&nbsp;<span translate>Rename</span>
-                        </button>
-                        <button type="button" class="btn btn-link btn-sm" ng-click="deleteWebauthnCredential(cred)">
-                          <span class="fas fa-trash"></span>&nbsp;<span translate>Delete</span>
-                        </button>
-                      </div>
+                  <div class="row">
+                    <div class="col-md-12">
+                      <button type="button" class="btn btn-link btn-sm" ng-click="webauthn.editingCredentialIds[cred.id] = true" ng-disabled="webauthn.editingCredentialIds[cred.id]">
+                        <span class="fas fa-edit"></span>&nbsp;<span translate>Rename</span>
+                      </button>
+                      <button type="button" class="btn btn-link btn-sm" ng-click="deleteWebauthnCredential(cred)">
+                        <span class="fas fa-trash"></span>&nbsp;<span translate>Delete</span>
+                      </button>
                     </div>
                   </div>
                 </div>
+              </div>
 
-                <div class="webauthn-credential-card panel">
-                  <div class="panel-body text-center">
-                    <button type="button" class="btn btn-link btn-sm" ng-click="registerWebauthnCredential()" ng-disabled="!webauthnReady()">
-                      <span class="fas fa-plus"></span>&nbsp;<span translate>Add passkey</span>
-                    </button>
-                  </div>
+              <div class="webauthn-credential-card panel">
+                <div class="panel-body text-center">
+                  <button type="button" class="btn btn-link btn-sm" ng-click="registerWebauthnCredential()" ng-disabled="!webauthnReady()">
+                    <span class="fas fa-plus"></span>&nbsp;<span translate>Add passkey</span>
+                  </button>
                 </div>
               </div>
             </div>
@@ -316,55 +246,8 @@
               <button ng-if="tmpGUI && !settingsModified()" type="button" class="btn btn-primary" ng-click="reloadSettingsAtWebauthnAddress(false)" translate translate-value-address="{{ getWebauthnOrigin() }}">Reload page at {%address%}</button>
             </p>
 
-            <!-- Ineligible WebAuthn credentials: >xs devices -->
-            <div class="webauthn-credentials hidden-xs" ng-repeat="_ in tmpGUI.webauthnState.credentials | filter:{rpId: '!'+tmpGUI.webauthnRpId}:true | limitTo:1">
-              <label translate>Ineligible WebAuthn Credentials (Passkeys)</label>
-              <p translate>The credentials below were created with a different setting of "Webauthn Rp Id" in advanced settings. They cannot be used without restoring this setting to the value shown as "RP ID" below. Note that doing so would make any credentials above ineligible instead.</p>
-              <div class="table-responsive">
-                <table class="table-striped table">
-                  <thead>
-                    <tr>
-                      <th><label translate="settings.webauthn.credentials.columnHeading.name">Name</label></th>
-                      <th><label translate>RP ID</label></th><!-- RP ID is the name of the WebAuthn setting, may not be translatable -->
-                      <th><label translate="settings.webauthn.credentials.columnHeading.createTime">Created</label></th>
-                      <th colspan="1000"><label translate>Actions</label></th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr ng-repeat="cred in tmpGUI.webauthnState.credentials | filter:{rpId: '!'+tmpGUI.webauthnRpId}:true">
-                      <td ng-if="!webauthn.editingCredentialIds[cred.id]" class="no-overflow-ellipse stretch text-warning">
-                        <span class="fas fa-exclamation-triangle"></span>
-                        {{ cred.nickname || (cred.id | limitTo: 20) }}
-                      </td>
-                      <td ng-if="webauthn.editingCredentialIds[cred.id]" class="no-overflow-ellipse stretch">
-                        <input class="form-control" type="text" ng-model="cred.nickname" placeholder="{{ cred.id }}" />
-                      </td>
-
-                      <td class="text-monospace text-nowrap">
-                        {{ cred.rpId }}
-                      </td>
-                      <td class="small-data" title="{{cred.createTime | date:'yyyy-MM-dd HH:mm:ss'}}">
-                        {{cred.createTime | date:'yyyy-MM-dd'}}
-                      </td>
-
-                      <td class="small-data button-cell">
-                        <button type="button" class="btn btn-link btn-sm" ng-click="webauthn.editingCredentialIds[cred.id] = true" ng-disabled="webauthn.editingCredentialIds[cred.id]">
-                          <span class="fas fa-edit"></span>&nbsp;<span translate>Rename</span>
-                        </button>
-                      </td>
-                      <td class="small-data button-cell">
-                        <button type="button" class="btn btn-link btn-sm" ng-click="deleteWebauthnCredential(cred)">
-                          <span class="fas fa-trash"></span>&nbsp;<span translate>Delete</span>
-                        </button>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-            </div>
-
-            <!-- Ineligible WebAuthn credentials: xs devices -->
-            <div class="visible-xs-block" ng-repeat="_ in tmpGUI.webauthnState.credentials | filter:{rpId: '!'+tmpGUI.webauthnRpId}:true | limitTo:1">
+            <!-- Ineligible WebAuthn credentials -->
+            <div ng-repeat="_ in tmpGUI.webauthnState.credentials | filter:{rpId: '!'+tmpGUI.webauthnRpId}:true | limitTo:1">
               <label translate>Ineligible WebAuthn Credentials (Passkeys)</label>
               <p translate>The credentials below were created with a different setting of "Webauthn Rp Id" in advanced settings. They cannot be used without restoring this setting to the value shown as "RP ID" below. Note that doing so would make any credentials above ineligible instead.</p>
               <div class="webauthn-credentials">

--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -168,7 +168,7 @@
             <a href="{{docsURL('users/webauthn')}}" target="_blank">
               <span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span>
             </a>
-            <div class="webauthn-credentials">
+            <div class="webauthn-credentials two-column-flexbox">
               <div class="webauthn-credential-card panel panel-default" ng-repeat="cred in tmpGUI.webauthnState.credentials | filter:{rpId: tmpGUI.webauthnRpId}:true">
                 <div class="panel-heading" ng-if="!webauthn.editingCredentialIds[cred.id]">
                   {{ cred.nickname || (cred.id | limitTo: 20) }}
@@ -250,7 +250,7 @@
             <div ng-repeat="_ in tmpGUI.webauthnState.credentials | filter:{rpId: '!'+tmpGUI.webauthnRpId}:true | limitTo:1">
               <label translate>Ineligible WebAuthn Credentials (Passkeys)</label>
               <p translate>The credentials below were created with a different setting of "Webauthn Rp Id" in advanced settings. They cannot be used without restoring this setting to the value shown as "RP ID" below. Note that doing so would make any credentials above ineligible instead.</p>
-              <div class="webauthn-credentials">
+              <div class="webauthn-credentials two-column-flexbox">
                 <div class="webauthn-credential-card panel panel-default" ng-repeat="cred in tmpGUI.webauthnState.credentials | filter:{rpId: '!'+tmpGUI.webauthnRpId}:true">
                   <div class="panel-heading">
                     <span class="text-warning">


### PR DESCRIPTION
Experiment to address https://github.com/syncthing/syncthing/pull/9175#discussion_r1730424638. This changes the display of the "WebAuthn Credentials" tables to use a card layout instead of the table on small displays.

I tried the card layout on bigger displays too, but it felt much too cluttered in my opinion. I find the table layout much easier to parse and get an overview of.

@acolomb thoughts on this?