### PR TITLE
Move setup-auth warning translation strings to explicit translation keys

### DIFF
--- a/gui/default/assets/lang/lang-ar.json
+++ b/gui/default/assets/lang/lang-ar.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "الواجهة / API وثيقة HTTPS",
     "GUI Authentication Password": "كلمة السر لتوثيق الواجهة",
     "GUI Authentication User": "اسم المستخدم لدخول واجهة الرسومية",
-    "GUI Authentication: Set User and Password": "توثيق الواجهة: أنشئ كلمة مرور للمستخدم",
     "GUI Listen Address": "عنوان ترقب الواجهة الرسومية",
     "GUI Override Directory": "مجلد إحلال الواجهة",
     "GUI Theme": "شكل الواجهة",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "ومع ذلك، تشير إعداداتك الحالية إلى أنك قد لا ترغب في تمكينه. لذلك توقف الإبلاغ التلقائي عن الأعطال.",
     "Identification": "المُعرِّف",
     "If untrusted, enter encryption password": "في حالة الرِّيبة، أدخل كلمة سر التشفير",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "إذا أردت منع المستخدمين الآخرين على هذا الحاسب من الوصول لملفاتك من خلال Syncthing، يُنصَح بإعداد وثائق الملكية.",
     "Ignore": "تجاهل",
     "Ignore Patterns": "تجاهل الأنماط",
     "Ignore Permissions": "تجاهل الصلاحيات",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "المسح الدوري خلال فترة زمنية معينة وفشل إعداد تَرقُّب التغييرات، إعادة المحاولة كل 1 دقيقة:",
     "Permanently add it to the ignore list, suppressing further notifications.": "أدرجها أبداً على قائمة التجاهل، اكتم الإشعارات مستقبلا.",
     "Please consult the release notes before performing a major upgrade.": "يرجى العودة إلى ملاحظات الإصدار قبل تنفيذ ترقية رئيسية.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "تفضل بإنشاء مستخدما موثقا للواجهة وكلمة مرور من خلال قائمة الإعدادات.",
     "Please wait": "يرجى الانتظار",
     "Prefix indicating that the file can be deleted if preventing directory removal": "سابقة تشير بإمكانية حذف الملف إذا منع إزالة المجلد",
     "Prefix indicating that the pattern should be matched without case sensitivity": "سابقة تعني عدم لزوم حالة الحرف في البحث (غير مهمة للعربية)",
@@ -415,7 +412,6 @@
     "Take me back": "رجوع",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "خيارات البدء حلَّت محل عنوان الواجهة. هذه التعديلات لن تدخل حيز التنفيذ ما بقي هذا الإحلال.",
     "The Syncthing Authors": "مُلَّاكُ Syncthing",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "واجهة مدير Syncthing معدة للسماح بالوصول بغير كلمة مرور.",
     "The aggregated statistics are publicly available at the URL below.": "الإحصاءات المجمعة متاحة للجميع على العنوان التالي.",
     "The cleanup interval cannot be blank.": "المدة بين عمليات التنظيف لا يمكن تركها فارغة.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "حفظت الإعدادات ولكن لم تفعَّل بعد. يجب أعادة تشغيل Syncthing حتى تفعَّل الإعدادات.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "تُعاد المحاولة تلقائيًا وستزامن عند إصلاح الخطأ.",
     "This Device": "هذا الجهاز",
     "This Month": "هذا الشهر",
-    "This can easily give hackers access to read and change any files on your computer.": "هذا قد يسبب في اختراق جهازك.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "لا يمكن لهذا الجهاز أن يرصد الأجهزة الأخرى تلقائيا، ولا أن يعلن عنوانه ليمكن الأجهزة الأخرى من إيجاده. الأجهزة ثابتة العناوين فقط يمكن أن تتصل.",
     "This is a major version upgrade.": "ترقية أساسية.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "هذا الخيار يتحكم في المساحة الفارغة المطلوبة من القرص الرئيسي.",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "استخدم إشعارات نظام الملفات لمعرفة الملفات المتغيرة.",
     "User": "مستخدِم",
     "User Home": "منزل المستخدم",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "اسم المستخدم/كلمة المرور لم يُنشَآ لتوثيق الواجهة. يُرجى إنشاؤهما من فضلك.",
     "Using a QUIC connection over LAN": "استخدام اتصال QUIC بدلا من LAN",
     "Using a QUIC connection over WAN": "استخدام اتصال QUIC بدلا من WAN",
     "Using a direct TCP connection over LAN": "استخدام اتصال TCP مباشر بدلا من LAN",
@@ -540,6 +534,18 @@
     "modified": "عُدِّل",
     "permit": "اسمح",
     "seconds": "ثواني",
+    "setup-auth": {
+        "notification": {
+            "body-1": "اسم المستخدم/كلمة المرور لم يُنشَآ لتوثيق الواجهة. يُرجى إنشاؤهما من فضلك.",
+            "body-2": "إذا أردت منع المستخدمين الآخرين على هذا الحاسب من الوصول لملفاتك من خلال Syncthing، يُنصَح بإعداد وثائق الملكية.",
+            "title": "توثيق الواجهة: أنشئ كلمة مرور للمستخدم"
+        },
+        "warning": {
+            "body-1": "واجهة مدير Syncthing معدة للسماح بالوصول بغير كلمة مرور.",
+            "body-2": "هذا قد يسبب في اختراق جهازك.",
+            "body-3": "تفضل بإنشاء مستخدما موثقا للواجهة وكلمة مرور من خلال قائمة الإعدادات."
+        }
+    },
     "theme": {
         "name": {
             "black": "أسوَد",

--- a/gui/default/assets/lang/lang-bg.json
+++ b/gui/default/assets/lang/lang-bg.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "Сертификат на интерфейса / ППИ през HTTPS",
     "GUI Authentication Password": "Парола за интерфейса",
     "GUI Authentication User": "Потребител за интерфейса",
-    "GUI Authentication: Set User and Password": "Удостоверяване на графичния интерфейс: потребител и парола",
     "GUI Listen Address": "Адрес на слушане",
     "GUI Override Directory": "Папка за промяна на интерфейса",
     "GUI Theme": "Тема на графичния интерфейс",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Текущите настройки обаче показват, че може би не искате да бъде включена. За това автоматичното докладване на сривове е изключено.",
     "Identification": "Идентифициране",
     "If untrusted, enter encryption password": "При недоверено задайте парола за шифроване",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Ако желаете да предотвратите достъпа на другите потребители на устройството до Syncthing, а чрез него и до файловете ви, помислете за удостоверяване на графичния интерфейс.",
     "Ignore": "Пренебрегване",
     "Ignore Patterns": "Шаблони за пренебрегване",
     "Ignore Permissions": "Пренебрегване на права",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Периодично обхождане и грешка при започване на наблюдението за промени, прави се опит всяка минута:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Добавяне за постоянно в списъка с пренебрегнати елементи, потискайки бъдещи известия.",
     "Please consult the release notes before performing a major upgrade.": "Прочетете бележките по изданието преди да пристъпите към обновяване към значимо издание.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Задайте потребителско име и парола за графичния интерфейс в настройките.",
     "Please wait": "Изчакайте",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Представка, указваща че файлът може да бъде изтрит ако пречи при премахване на папката",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Представка, указваща че шаблонът не прави разлика в регистъра на буквите",
@@ -415,7 +412,6 @@
     "Take me back": "Назад",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "Адресът на интерфейса не се взима под внимание заради параметри при стартиране. Промените тук няма да бъдат отразени докато параметрите не бъдат променени.",
     "The Syncthing Authors": "Автори на Syncthing",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Администраторският панел на Syncthing разрешава дистанционен достъп без да изисква парола.",
     "The aggregated statistics are publicly available at the URL below.": "Обобщените статистически данни са публично достъпни на адреса по-долу.",
     "The cleanup interval cannot be blank.": "Интервалът на почистване не може да бъде празен.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Настройките са запазени, но не са приложени. За да влязат в сила Syncthing трябва да се рестартира.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Ще бъдат спрени и автоматично синхронизирани, когато грешката бъде отстранена.",
     "This Device": "Това устройство",
     "This Month": "Този месец",
-    "This can easily give hackers access to read and change any files on your computer.": "Така се предоставя лесен достъп за четене и промяна на всеки файл на компютъра.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Устройството не може автоматично да открива други устройства или да обяви своя адрес, за да бъде намерено от другите. Само устройствата със статично настроени адреси могат да се свързват.",
     "This is a major version upgrade.": "Това е обновяване на значимо издание.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Тази настройка управлява нужното свободното място на основния (пр. този с банката от данни) диск.",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "Използва съобщения от файловата система, за да открива променени елементи.",
     "User": "Потребител",
     "User Home": "Папка на потребителя",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Потребителският интерфейс не е защитен с потребителско име и парола. Настройте защита.",
     "Using a QUIC connection over LAN": "Използване на връзка чрез QUIC в LAN",
     "Using a QUIC connection over WAN": "Използване на връзка чрез QUIC в WAN",
     "Using a direct TCP connection over LAN": "Използване на директна свързаност с TCP през местна мрежа",
@@ -540,6 +534,18 @@
     "modified": "променено",
     "permit": "разрешаване",
     "seconds": "секунди",
+    "setup-auth": {
+      "notification": {
+        "body-1": "Потребителският интерфейс не е защитен с потребителско име и парола. Настройте защита.",
+        "body-2": "Ако желаете да предотвратите достъпа на другите потребители на устройството до Syncthing, а чрез него и до файловете ви, помислете за удостоверяване на графичния интерфейс.",
+        "title": "Удостоверяване на графичния интерфейс: потребител и парола"
+      },
+      "warning": {
+        "body-1": "Администраторският панел на Syncthing разрешава дистанционен достъп без да изисква парола.",
+        "body-2": "Така се предоставя лесен достъп за четене и промяна на всеки файл на компютъра.",
+        "body-3": "Задайте потребителско име и парола за графичния интерфейс в настройките."
+      }
+    },
     "theme": {
         "name": {
             "black": "Черна",

--- a/gui/default/assets/lang/lang-ca.json
+++ b/gui/default/assets/lang/lang-ca.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "Certificat HTTPS GUI / API",
     "GUI Authentication Password": "Contrasenya d'autenticació GUI",
     "GUI Authentication User": "Usuari d'autenticació GUI",
-    "GUI Authentication: Set User and Password": "Autenticació de la GUI: defineix l'usuari i la contrasenya",
     "GUI Listen Address": "Adreça d'escolta de la GUI",
     "GUI Override Directory": "Directori de substitució de la GUI",
     "GUI Theme": "Tema de la GUI",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Tanmateix, la vostra configuració actual indica que potser no voleu que estigui activada. Hem desactivat l'informe automàtic d'errors.",
     "Identification": "Identificació",
     "If untrusted, enter encryption password": "Si no és de confiança, introduïu la contrasenya de xifratge",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Si voleu evitar que altres usuaris d'aquest ordinador accedeixin a Syncthing i a través d'ell els vostres fitxers, penseu a configurar l'autenticació.",
     "Ignore": "Ignorar",
     "Ignore Patterns": "Patrons d'ignoració",
     "Ignore Permissions": "Ignora Permisos",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "L'escaneig periòdic determinat a un interval ha fallat i no s'ha pogut configurar l'observació dels canvis, tornant-ho a provar cada 1 minut:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Afegeix-lo permanentment a la llista d'ignorar, suprimint més notificacions.",
     "Please consult the release notes before performing a major upgrade.": "Si us plau consulta les notes de llançament abans de realitzar una actualització major.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Si us plau, estableix un usuari i contrasenya al GUI a través del quadre de diàleg de configuració.",
     "Please wait": "Si-us-plau espera",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Prefix que indica que el fitxer es pot suprimir si s'impedeix l'eliminació del directori",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Prefix que indica que el patró s'ha de fer coincidir sense distinció de majúscules i minúscules",
@@ -415,7 +412,6 @@
     "Take me back": "Porta'm enrere",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "Les opcions d'inici substitueixen l'adreça de la GUI. Els canvis aquí no tindran efecte mentre la substitució estigui vigent.",
     "The Syncthing Authors": "Els autors de Syncthing",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "La interfície d'administració de Syncthing està configurada per permetre l'accés remot sense contrasenya.",
     "The aggregated statistics are publicly available at the URL below.": "Les estadístiques agregades estan disponibles públicament a l'URL següent.",
     "The cleanup interval cannot be blank.": "L'interval de neteja no pot estar en blanc.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "La configuració s'ha desat, però no s'ha activat. S'ha de reiniciar el Synthing per a activar la configuració nova.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Són reintentats automàticament i seran sincronitzats quan l'error estigui resolt.",
     "This Device": "Aquest dispositiu",
     "This Month": "Aquest mes",
-    "This can easily give hackers access to read and change any files on your computer.": "Això pot donar facilment accés a hackers per llegir i canviar qualsevol fitxer del teu ordinador.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Aquest dispositiu no pot detectar automàticament altres dispositius ni anunciar la seva pròpia adreça perquè altres puguin trobar.   Només es poden connectar dispositius amb adreces configurades estàticament.",
     "This is a major version upgrade.": "Aquesta és una actualització de versió major.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Aquesta configuració controla l'espai lliure necessari al disc d'inici (és a dir, la base de dades d'índex).",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "Utilitzeu les notificacions del sistema de fitxers per detectar elements canviats.",
     "User": "Usuari",
     "User Home": "Carpeta d'inici de l'usuari",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "El nom d'usuari/contrasenya no s'ha establert per a l'autenticació de la GUI. Penseu a configurar-lo.",
     "Using a QUIC connection over LAN": "Utilitzant una connexió QUIC per LAN",
     "Using a QUIC connection over WAN": "Utilitzant una connexió QUIC a través de WAN",
     "Using a direct TCP connection over LAN": "Utilitzant una connexió TCP directa per LAN",
@@ -540,6 +534,18 @@
     "modified": "modificat",
     "permit": "permís",
     "seconds": "segons",
+    "setup-auth": {
+        "notification": {
+            "body-1": "El nom d'usuari/contrasenya no s'ha establert per a l'autenticació de la GUI. Penseu a configurar-lo.",
+            "body-2": "Si voleu evitar que altres usuaris d'aquest ordinador accedeixin a Syncthing i a través d'ell els vostres fitxers, penseu a configurar l'autenticació.",
+            "title": "Autenticació de la GUI: defineix l'usuari i la contrasenya"
+        },
+        "warning": {
+            "body-1": "La interfície d'administració de Syncthing està configurada per permetre l'accés remot sense contrasenya.",
+            "body-2": "Això pot donar facilment accés a hackers per llegir i canviar qualsevol fitxer del teu ordinador.",
+            "body-3": "Si us plau, estableix un usuari i contrasenya al GUI a través del quadre de diàleg de configuració."
+        }
+    },
     "theme": {
         "name": {
             "black": "Negre",

--- a/gui/default/assets/lang/lang-ca@valencia.json
+++ b/gui/default/assets/lang/lang-ca@valencia.json
@@ -176,7 +176,6 @@
     "GUI / API HTTPS Certificate": "Certificat HTTPS GUI / API",
     "GUI Authentication Password": "Password d'autenticació de l'Interfície Gràfica d'Usuari (GUI)",
     "GUI Authentication User": "Autenticació de l'usuari de l'Interfície Gràfica d'Usuari (GUI)",
-    "GUI Authentication: Set User and Password": "Autenticació de la interfície gràfica d'usuari: defineix l'usuari i la contrasenya",
     "GUI Listen Address": "Adreça d'escolta de la Interfície Gràfica d'Usuari (GUI)",
     "GUI Override Directory": "Directori de substitució de la interfície gràfica d'usuari",
     "GUI Theme": "Tema de l'Interfície Gràfica d'Usuari (GUI)",
@@ -191,7 +190,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Tanmateix, la vostra configuració actual indica que potser no voleu que estigui activada. Hem desactivat l'informe automàtic d'errors.",
     "Identification": "Identificació",
     "If untrusted, enter encryption password": "Si no és de confiança, introduïu la contrasenya de xifratge",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Si voleu evitar que altres usuaris d'aquest ordinador accedeixin a Syncthing i a través d'ell els vostres fitxers, penseu a configurar l'autenticació.",
     "Ignore": "Ignorar",
     "Ignore Patterns": "Patrons a ignorar",
     "Ignore Permissions": "Permisos a ignorar",
@@ -282,7 +280,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Escaneig periòdic a l'interval determinat i errada al activar el rastreig continu de canvis, reintentant cada 1 minut:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Afegeix-lo permanentment a la llista d'ignorar, suprimint més notificacions.",
     "Please consult the release notes before performing a major upgrade.": "Per favor, consultar les notes de la versió abans de fer una actualització important.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Per favor, estableix un usuari i password per a l'Interfície Gràfica d'Usuari en el menú d'Adjustos.",
     "Please wait": "Per favor, espere",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Prefix que indica que el fitxer pot ser eliminat encara que estiga restringida l'eliminació del directori",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Prefix que indica que el patró deu coincidir sense tindre en compte les majúscules",
@@ -398,7 +395,6 @@
     "Take me back": "Porta'm enrere",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "L'adreça del GUI és sobreescrita per les opcions d'inici. Els canvis ací no surtiràn efecte mentre la sobreescritura estiga en marxa.",
     "The Syncthing Authors": "Els autors de Syncthing",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "L'interfície d'administració de Syncthing està configurat per a permetre l'accés remot sense una contrasenya.",
     "The aggregated statistics are publicly available at the URL below.": "Les estadístiques agregades estàn disponibles en la URL que figura a continuació.",
     "The cleanup interval cannot be blank.": "L'interval de neteja no pot estar en blanc.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "La configuració ha sigut gravada però no activada. Syncthing deu reiniciar per tal d'activar la nova configuració.",
@@ -436,7 +432,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Es reintenta automàticament i es sincronitzaràn quant el resolga l'error.",
     "This Device": "Aquest Dispositiu",
     "This Month": "Aquest mes",
-    "This can easily give hackers access to read and change any files on your computer.": "Açò pot donar accés fàcilment als hackers per a llegir i canviar qualsevol fitxer al teu ordinador.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Aquest dispositiu no pot detectar automàticament altres dispositius ni anunciar la seva pròpia adreça perquè altres puguin trobar. Només es poden connectar dispositius amb adreces configurades estàticament.",
     "This is a major version upgrade.": "Aquesta és una actualització important de la versió.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Aquest ajust controla l'espai lliure requerit en el disc inicial (per exemple, la base de dades de l'index).",
@@ -471,7 +466,6 @@
     "Use HTTPS for GUI": "Utilitzar HTTPS per a l'Interfície Gràfica d'Usuari (GUI)",
     "Use notifications from the filesystem to detect changed items.": "Usar notificacions del sistema de fitxers per a detectar els ítems canviats.",
     "User Home": "Carpeta d'inici de l'usuari",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "El nom d'usuari/contrasenya no s'ha establert per a l'autenticació de la interfície gràfica d'usuari. Penseu a configurar-ho.",
     "Using a direct TCP connection over LAN": "Utilitzant una connexió TCP directa per LAN",
     "Using a direct TCP connection over WAN": "Utilitzant una connexió TCP directa a través de WAN",
     "Version": "Versió",
@@ -517,6 +511,18 @@
     "modified": "modificat",
     "permit": "permís",
     "seconds": "segons",
+    "setup-auth": {
+        "notification": {
+            "body-1": "El nom d'usuari/contrasenya no s'ha establert per a l'autenticació de la interfície gràfica d'usuari. Penseu a configurar-ho.",
+            "body-2": "Si voleu evitar que altres usuaris d'aquest ordinador accedeixin a Syncthing i a través d'ell els vostres fitxers, penseu a configurar l'autenticació.",
+            "title": "Autenticació de la interfície gràfica d'usuari: defineix l'usuari i la contrasenya"
+        },
+        "warning": {
+            "body-1": "L'interfície d'administració de Syncthing està configurat per a permetre l'accés remot sense una contrasenya.",
+            "body-2": "Açò pot donar accés fàcilment als hackers per a llegir i canviar qualsevol fitxer al teu ordinador.",
+            "body-3": "Per favor, estableix un usuari i password per a l'Interfície Gràfica d'Usuari en el menú d'Adjustos."
+        }
+    },
     "theme": {
         "name": {
             "black": "Negre",

--- a/gui/default/assets/lang/lang-cs.json
+++ b/gui/default/assets/lang/lang-cs.json
@@ -180,7 +180,6 @@
     "GUI / API HTTPS Certificate": "Certifikát GUI / API HTTPS",
     "GUI Authentication Password": "Přihlašovací heslo pro GUI",
     "GUI Authentication User": "Přihlašovací jméno pro GUI",
-    "GUI Authentication: Set User and Password": "Ověřování v graf. uživatelském rozhraní: Nastavit uživatele a heslo",
     "GUI Listen Address": "Adresa, na které GUI očekává spojení",
     "GUI Override Directory": "Složka pro GUI Override",
     "GUI Theme": "Motiv vzhledu pro GUI",
@@ -194,7 +193,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Nicméně Vaše současná nastavení značí, že si nepřejete funkci povolit. Automatické hlášení pádů tedy bylo vypnuto.",
     "Identification": "Identifikace",
     "If untrusted, enter encryption password": "V případě nedůvěryhodnosti zadat šifrovací heslo",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Pokud chcete ostatním uživatelům tohoto počítače zabránit v přístupu k Syncthing (a skrze něj tedy ke svým souborům), zvažte nastavení ověřování se.",
     "Ignore": "Ignorovat",
     "Ignore Patterns": "Vzory ignorovaného",
     "Ignore Permissions": "Ignorovat oprávnění",
@@ -293,7 +291,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Periodické skenování podle zadaného intervalu; nastavení sledování změn se nezdařilo, opětovný pokus každou 1 min:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Natrvalo ignorovat, takže oznámení již nebudou přicházet.",
     "Please consult the release notes before performing a major upgrade.": "Před přechodem na novější hlavní verzi si nejdříve přečtěte poznámky k vydání nové verze.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "V dialogu Nastavení zadejte uživatelské jméno a heslo pro ověření se v GUI.",
     "Please wait": "Chvíli strpení",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Tato předpona značí, že pokud soubor brání odebrání složky, je možné ho smazat",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Tato předpona značí, že při porovnávání se vzorem nemají být rozlišována malá/velká písmena",
@@ -401,7 +398,6 @@
     "Take me back": "Jít zpět",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "Adresa v GUI je potlačena parametry při spuštění. Dokud potlačení trvá, zdejší změny nemají efekt.",
     "The Syncthing Authors": "Autoři Syncthing",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "V nastavení aplikace Syncthing je povoleno vzdálené připojení k administrátorskému rozhraní bez zadání hesla.",
     "The aggregated statistics are publicly available at the URL below.": "Souhrnné statistiky jsou veřejně dostupné na níže uvedené URL.",
     "The cleanup interval cannot be blank.": "Interval mazání nesmí být prázdný.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Nastavení byla uložena, ale nejsou aktivována. Pro aktivaci nového nastavení je třeba Syncthing restartovat.",
@@ -440,7 +436,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Nové pokusy o synchronizaci budou probíhat automaticky a položky budou synchronizovány jakmile bude chyba odstraněna.",
     "This Device": "Toto zařízení",
     "This Month": "Tento měsíc",
-    "This can easily give hackers access to read and change any files on your computer.": "Toto může útočníkům jednoduše umožnit čtení a úpravy souborů na vašem počítači. ",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Toto zařízení nemůže automaticky objevovat ostatní zařízení ani oznamovat ostatním vlastní adresu. Připojit se mohou jen zařízení se staticky nastavenou adresou.",
     "This is a major version upgrade.": "Toto je velká aktualizace.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Toto nastavení ovládá velikost volného prostoru na hlavním datovém úložišti (to, na kterém je databáze rejstříku).",
@@ -473,7 +468,6 @@
     "Use HTTPS for GUI": "Použít pro grafické rozhraní zabezpečení HTTPS",
     "Use notifications from the filesystem to detect changed items.": "Použít oznamování soubor. systému pro nalezení změněných položek.",
     "User Home": "Domácí adresář uživatele",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Pro ověřování v grafickém uživatelském rozhraní nebylo nastaveno uživatelské jméno / heslo. Prosím zvažte nastavení nějakého.",
     "Version": "Verze",
     "Versions": "Verze",
     "Versions Path": "Popis umístění verzí",
@@ -512,6 +506,18 @@
     "modified": "změněno",
     "permit": "povolit",
     "seconds": "sekund",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Pro ověřování v grafickém uživatelském rozhraní nebylo nastaveno uživatelské jméno / heslo. Prosím zvažte nastavení nějakého.",
+            "body-2": "Pokud chcete ostatním uživatelům tohoto počítače zabránit v přístupu k Syncthing (a skrze něj tedy ke svým souborům), zvažte nastavení ověřování se.",
+            "title": "Ověřování v graf. uživatelském rozhraní: Nastavit uživatele a heslo"
+        },
+        "warning": {
+            "body-1": "V nastavení aplikace Syncthing je povoleno vzdálené připojení k administrátorskému rozhraní bez zadání hesla.",
+            "body-2": "Toto může útočníkům jednoduše umožnit čtení a úpravy souborů na vašem počítači. ",
+            "body-3": "V dialogu Nastavení zadejte uživatelské jméno a heslo pro ověření se v GUI."
+        }
+    },
     "theme": {
         "name": {
             "black": "Černý",

--- a/gui/default/assets/lang/lang-da.json
+++ b/gui/default/assets/lang/lang-da.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "GUI / API HTTPS-certifikat",
     "GUI Authentication Password": "GUI-adgangskode",
     "GUI Authentication User": "GUI-brugernavn",
-    "GUI Authentication: Set User and Password": "GUI godkendelse: Angiv bruger og adgangskode",
     "GUI Listen Address": "GUI-lytteadresse",
     "GUI Override Directory": "Mappe til GUI-tilsidesættelse",
     "GUI Theme": "GUI-tema",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Dine nuværende indstillinger tyder dog på, at du måske ikke ønsker det aktiveret. Vi har deaktiveret automatisk nedbrudsrapportering for dig.",
     "Identification": "Identifikation",
     "If untrusted, enter encryption password": "Hvis ikke troværdig, indtast krypteringsadgangskode",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Hvis du vil forhindre andre brugere på denne computer i at få adgang til Syncthing og dermed til dine filer, skal du overveje at konfigurere godkendelse.",
     "Ignore": "Ignorér",
     "Ignore Patterns": "Ignoreringsmønstre",
     "Ignore Permissions": "Ignorér rettigheder",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Periodisk skanning med et givent interval og lykkedes ikke med at opsætte overvågning af ændringer; prøver igen hvert minut:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Permanent tilføj til ignore liste, undertrykker yderligere påmindelse.",
     "Please consult the release notes before performing a major upgrade.": "Tjek venligst udgivelsesnoterne før opgradering til en ny hovedversion.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Opret venligst en GUI-bruger og -adgangskode i opsætningen.",
     "Please wait": "Vent venligst",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Forstavelse, der indikerer, at filen kan slettes, hvis fjernelse at mappe undgåes",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Forstavelse, der indikerer det mønster, der skal sammenlignes uden versalfølsomhed",
@@ -415,7 +412,6 @@
     "Take me back": "Tag mig tilbage",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "GUI-adressen tilsidesættes af opstartsindstillingerne. Ændringer her vil ikke træde i kraft, så længe tilsidesættelsen er i kraft.",
     "The Syncthing Authors": "Syncthing udviklere",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Syncthing-administationsfladen er sat op til at kunne fjernstyres uden adgangskode.",
     "The aggregated statistics are publicly available at the URL below.": "Den indsamlede statistik er offentligt tilgængelig på den nedenstående URL.",
     "The cleanup interval cannot be blank.": "Ryd op interval kan ikke være tom.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Konfigurationen er gemt, men ikke aktiveret. Syncthing skal genstarte for at aktivere den nye konfiguration.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "De prøves igen automatisk og vil blive synkroniseret, når fejlen er løst.",
     "This Device": "Denne enhed",
     "This Month": "Denne måned",
-    "This can easily give hackers access to read and change any files on your computer.": "Dette gør det nemt for hackere at få adgang til at læse og ændre filer på din computer.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Denne enhed kan ikke automatisk opdage andre enheder eller annoncere egen adresse som skal findes af andre enheder. Kun enheder med statisk konfigurerede adresser kan oprette forbindelse.",
     "This is a major version upgrade.": "Dette er en ny hovedversion.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Denne indstilling styrer den krævede ledige plads på hjemmedrevet (dvs. drevet med indeksdatabasen).",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "Benyt notifikationer fra filsystemet til at finde filændringer.",
     "User": "Bruger",
     "User Home": "Brugerhjem",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Brugernavn/adgangskode er ikke indstillet til GUI-godkendelse. Overvej at konfigurere det.",
     "Using a QUIC connection over LAN": "Brug af en QUIC-forbindelse over LAN",
     "Using a QUIC connection over WAN": "Brug af en QUIC-forbindelse over WAN",
     "Using a direct TCP connection over LAN": "Brug af en direkte TCP-forbindelse via LAN",
@@ -540,6 +534,18 @@
     "modified": "ændret",
     "permit": "tillad",
     "seconds": "sekunder",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Brugernavn/adgangskode er ikke indstillet til GUI-godkendelse. Overvej at konfigurere det.",
+            "body-2": "Hvis du vil forhindre andre brugere på denne computer i at få adgang til Syncthing og dermed til dine filer, skal du overveje at konfigurere godkendelse.",
+            "title": "GUI godkendelse: Angiv bruger og adgangskode"
+        },
+        "warning": {
+            "body-1": "Syncthing-administationsfladen er sat op til at kunne fjernstyres uden adgangskode.",
+            "body-2": "Dette gør det nemt for hackere at få adgang til at læse og ændre filer på din computer.",
+            "body-3": "Opret venligst en GUI-bruger og -adgangskode i opsætningen."
+        }
+    },
     "theme": {
         "name": {
             "black": "Sort",

--- a/gui/default/assets/lang/lang-de.json
+++ b/gui/default/assets/lang/lang-de.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "GUI / API HTTPS-Zertifikat",
     "GUI Authentication Password": "Passwort für Zugang zur Benutzeroberfläche",
     "GUI Authentication User": "Benutzername für Zugang zur Benutzeroberfläche",
-    "GUI Authentication: Set User and Password": "Authentifizierung für die Benutzeroberfläche: Geben Sie Benutzer und Passwort ein.",
     "GUI Listen Address": "Adresse der Benutzeroberfläche",
     "GUI Override Directory": "GUI-Ersatz-Verzeichnis",
     "GUI Theme": "GUI-Design",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Ihre aktuellen Einstellungen weisen jedoch daraufhin, dass Sie die Aktivierung möglicherweise nicht wünschen. Wir haben die automatischen Absturzberichte für Sie deaktiviert.",
     "Identification": "Kennung",
     "If untrusted, enter encryption password": "Wenn nicht vertraut, geben Sie das Verschlüsselungspasswort ein",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Falls Sie andere Benutzer dieses Computers am Zugriff auf Syncthing und somit Ihren Dateien hindern möchten, richten Sie bitte eine Authentifizierung ein.",
     "Ignore": "Ignorieren",
     "Ignore Patterns": "Ignoriermuster",
     "Ignore Permissions": "Berechtigungen ignorieren",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Periodischer Scan im angegebenen Intervall, Überwachung von Änderungen fehlgeschlagen, erneuter Versuch jede Minute:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Permanent zur Ignorierliste hinzufügen, um weitere Benachrichtigungen zu unterdrücken.",
     "Please consult the release notes before performing a major upgrade.": "Bitte lesen Sie die Veröffentlichungshinweise, bevor Sie eine Hauptversionsaktualisierung installieren.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Bitte legen Sie in den Einstellungen einen Benutzer und ein Passwort für die Benutzeroberfläche fest.",
     "Please wait": "Bitte warten",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Präfix, das anzeigt, dass die Datei gelöscht werden kann, wenn sie die Entfernung des Ordners verhindert",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Präfix, das anzeigt, dass das Muster ohne Beachtung der Groß-/Kleinschreibung abgeglichen werden soll",
@@ -415,7 +412,6 @@
     "Take me back": "Führen Sie mich zurück",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "Die GUI-Adresse wird durch Startoptionen überschrieben. Hier vorgenommene Änderungen werden nicht wirksam, solange die Überschreibung besteht.",
     "The Syncthing Authors": "Die Syncthing-Autoren",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Die Syncthing-Oberfläche erlaubt mit den jetzigen Einstellungen einen Zugriff ohne Passwort.",
     "The aggregated statistics are publicly available at the URL below.": "Die gesammelten Statistiken sind öffentlich unter der nachfolgenden URL verfügbar.",
     "The cleanup interval cannot be blank.": "Das Bereinigungsintervall darf nicht leer sein.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Die Konfiguration wurde gespeichert, aber noch nicht aktiviert. Syncthing muss neu gestartet werden, um die neue Konfiguration zu übernehmen.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Sie werden automatisch heruntergeladen und werden synchronisiert, wenn der Fehler behoben wurde.",
     "This Device": "Dieses Gerät",
     "This Month": "Dieser Monat",
-    "This can easily give hackers access to read and change any files on your computer.": "Dies kann dazu führen, dass Unberechtigte relativ einfach auf Ihre Dateien zugreifen und diese ändern können.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Dieses Gerät kann nicht automatisch andere Geräte auffinden oder seine eigene Adresse bekannt geben, um von anderen gefunden zu werden. Nur Geräte mit statisch konfigurierten Adressen können sich verbinden.",
     "This is a major version upgrade.": "Dies ist eine Hauptversionsaktualisierung.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Diese Einstellung regelt den freien Speicherplatz, der für den Systemordner (d. h. Indexdatenbank) erforderlich ist.",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "Benachrichtigungen des Dateisystems nutzen, um Änderungen zu erkennen.",
     "User": "Benutzer",
     "User Home": "Benutzer-Stammverzeichnis",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Benutzername / Passwort wurde für die Benutzeroberfläche nicht gesetzt. Bitte erwägen Sie, dies einzurichten.",
     "Using a QUIC connection over LAN": "Verwendet eine QUIC-Verbindung über LAN",
     "Using a QUIC connection over WAN": "Verwendet eine QUIC-Verbindung über WAN",
     "Using a direct TCP connection over LAN": "Verwendet eine direkte TCP-Verbindung über LAN",
@@ -540,6 +534,18 @@
     "modified": "geändert",
     "permit": "erlauben",
     "seconds": "Sekunden",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Benutzername / Passwort wurde für die Benutzeroberfläche nicht gesetzt. Bitte erwägen Sie, dies einzurichten.",
+            "body-2": "Falls Sie andere Benutzer dieses Computers am Zugriff auf Syncthing und somit Ihren Dateien hindern möchten, richten Sie bitte eine Authentifizierung ein.",
+            "title": "Authentifizierung für die Benutzeroberfläche: Geben Sie Benutzer und Passwort ein."
+        },
+        "warning": {
+            "body-1": "Die Syncthing-Oberfläche erlaubt mit den jetzigen Einstellungen einen Zugriff ohne Passwort.",
+            "body-2": "Dies kann dazu führen, dass Unberechtigte relativ einfach auf Ihre Dateien zugreifen und diese ändern können.",
+            "body-3": "Bitte legen Sie in den Einstellungen einen Benutzer und ein Passwort für die Benutzeroberfläche fest."
+        }
+    },
     "theme": {
         "name": {
             "black": "Schwarz",

--- a/gui/default/assets/lang/lang-el.json
+++ b/gui/default/assets/lang/lang-el.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "Πιστοποιητικό HTTPS για το GUI / API",
     "GUI Authentication Password": "Κωδικός για την πρόσβαση στη διεπαφή",
     "GUI Authentication User": "Χρηστώνυμο για την πρόσβαση στη διεπαφή",
-    "GUI Authentication: Set User and Password": "Έλεγχος ταυτότητας GUI: Ορισμός χρήστη και κωδικού πρόσβασης",
     "GUI Listen Address": "Διεύθυνση ακρόασης γραφικού περιβάλλοντος (GUI)",
     "GUI Override Directory": "Κατάλογος παράκαμψης GUI",
     "GUI Theme": "Θέμα GUI",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Ωστόσο, σύμφωνα με τις τρέχουσες ρυθμίσεις σας, μάλλον δεν επιθυμείτε αυτή τη λειτουργία. Οι αναφορές σφαλμάτων απενεργοποιήθηκαν.",
     "Identification": "Ταυτοποίηση",
     "If untrusted, enter encryption password": "Εάν δεν είναι αξιόπιστοι, εισαγάγετε έναν κωδικό πρόσβασης κρυπτογράφησης",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Εάν θέλετε να εμποδίσετε άλλους χρήστες σε αυτόν τον υπολογιστή να έχουν πρόσβαση στο Syncthing και μέσω αυτού στα αρχεία σας, εξετάστε το ενδεχόμενο να ρυθμίσετε τον έλεγχο ταυτότητας.",
     "Ignore": "Αγνόησε",
     "Ignore Patterns": "Πρότυπο για αγνόηση",
     "Ignore Permissions": "Αγνόησε τα δικαιώματα",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Τακτική σάρωση ανά καθορισμένο διάστημα και αποτυχία ενεργοποίησης επιτήρησης αλλαγών. Γίνεται νέα προσπάθεια κάθε 1m:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Προσθέστε το μόνιμα στη λίστα παράβλεψης, καταργώντας περαιτέρω ειδοποιήσεις.",
     "Please consult the release notes before performing a major upgrade.": "Παρακαλούμε, πριν από την εκτέλεση μιας σημαντικής αναβάθμισης, να συμβουλευτείς το σημείωμα που τη συνοδεύει.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Παρακαλώ όρισε στις ρυθμίσεις έναν χρήστη και έναν κωδικό πρόσβασης για τη διεπαφή.",
     "Please wait": "Παρακαλώ περιμένετε",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Πρόθεμα που δείχνει ότι το αρχείο θα μπορεί να διαγραφεί αν εμποδίζει τη διαγραφή καταλόγου",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Πρόθεμα που δείχνει ότι η αντιστοίχιση προτύπου θα γίνεται χωρίς διάκριση πεζών και κεφαλαίων χαρακτήρων",
@@ -415,7 +412,6 @@
     "Take me back": "Επιστροφή",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "Η διεύθυνση του GUI έχει τροποποιηθεί μέσω παραμέτρων εκκίνησης. Οι αλλαγές εδώ δεν θα ισχύσουν όσο είναι ενεργές αυτές οι παράμετροι.",
     "The Syncthing Authors": "Οι δημιουργοί του Syncthing",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Η διεπαφή διαχείρισης του Syncthing είναι ρυθμισμένη να επιτρέπει την πρόσβαση χωρίς κωδικό.",
     "The aggregated statistics are publicly available at the URL below.": "Τα στατιστικά που έχουν συλλεγεί είναι δημόσια διαθέσιμα στη παρακάτω διεύθυνση.",
     "The cleanup interval cannot be blank.": "Το διάστημα καθαρισμού δεν μπορεί να είναι κενό.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Οι ρυθμίσεις έχουν αποθηκευτεί αλλά δεν έχουν ενεργοποιηθεί. Πρέπει να επανεκκινήσεις το Syncthing για να ισχύσουν οι νέες ρυθμίσεις.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Όταν επιλυθεί το σφάλμα θα κατεβούν και θα συχρονιστούν αυτόματα.",
     "This Device": "Αυτή η συσκευή",
     "This Month": "Αυτο το μηνα",
-    "This can easily give hackers access to read and change any files on your computer.": "Αυτό μπορεί εύκολα να δώσει πρόσβαση ανάγνωσης και επεξεργασίας αρχείων του υπολογιστή σας σε χάκερς.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Αυτή η συσκευή δεν μπορεί να ανακαλύψει αυτόματα άλλες συσκευές ή να ανακοινώσει τη δική της διεύθυνση που θα βρεθεί από άλλους. Μόνο συσκευές με στατικά διαμορφωμένες διευθύνσεις μπορούν να συνδεθούν.",
     "This is a major version upgrade.": "Αυτή είναι μια σημαντική αναβάθμιση.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Αυτή η επιλογή καθορίζει τον ελεύθερο χώρο που θα παραμένει ελεύθερος στον δίσκο όπου βρίσκεται ο κατάλογος της εφαρμογής (και συνεπώς η βάση δεδομένων ευρετηρίων).",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "Χρήση ειδοποιήσεων από το σύστημα αρχείων για την ανίχνευση αλλαγών.",
     "User": "Χρήστης",
     "User Home": "Αρχική σελίδα χρήστη",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Όνομα χρήστη/Κωδικός πρόσβασης δεν έχει οριστεί για τον έλεγχο ταυτότητας GUI. Παρακαλώ σκεφτείτε να το ρυθμίσετε.",
     "Using a QUIC connection over LAN": "Χρήση σύνδεσης QUIC μέσω LAN",
     "Using a QUIC connection over WAN": "Χρήση σύνδεσης QUIC μέσω WAN",
     "Using a direct TCP connection over LAN": "Χρήση απευθείας σύνδεσης TCP μέσω LAN",
@@ -540,6 +534,18 @@
     "modified": "τροποποιήθηκε",
     "permit": "επιτρέπετε",
     "seconds": "δευτερόλεπτα",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Όνομα χρήστη/Κωδικός πρόσβασης δεν έχει οριστεί για τον έλεγχο ταυτότητας GUI. Παρακαλώ σκεφτείτε να το ρυθμίσετε.",
+            "body-2": "Εάν θέλετε να εμποδίσετε άλλους χρήστες σε αυτόν τον υπολογιστή να έχουν πρόσβαση στο Syncthing και μέσω αυτού στα αρχεία σας, εξετάστε το ενδεχόμενο να ρυθμίσετε τον έλεγχο ταυτότητας.",
+            "title": "Έλεγχος ταυτότητας GUI: Ορισμός χρήστη και κωδικού πρόσβασης"
+        },
+        "warning": {
+            "body-1": "Η διεπαφή διαχείρισης του Syncthing είναι ρυθμισμένη να επιτρέπει την πρόσβαση χωρίς κωδικό.",
+            "body-2": "Αυτό μπορεί εύκολα να δώσει πρόσβαση ανάγνωσης και επεξεργασίας αρχείων του υπολογιστή σας σε χάκερς.",
+            "body-3": "Παρακαλώ όρισε στις ρυθμίσεις έναν χρήστη και έναν κωδικό πρόσβασης για τη διεπαφή."
+        }
+    },
     "theme": {
         "name": {
             "black": "Μαύρο",

--- a/gui/default/assets/lang/lang-en-AU.json
+++ b/gui/default/assets/lang/lang-en-AU.json
@@ -176,7 +176,6 @@
     "GUI / API HTTPS Certificate": "GUI / API HTTPS Certificate",
     "GUI Authentication Password": "GUI Authentication Password",
     "GUI Authentication User": "GUI Authentication User",
-    "GUI Authentication: Set User and Password": "GUI Authentication: Set User and Password",
     "GUI Listen Address": "GUI Listen Address",
     "GUI Override Directory": "GUI Override Directory",
     "GUI Theme": "GUI Theme",
@@ -191,7 +190,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.",
     "Identification": "Identification",
     "If untrusted, enter encryption password": "If untrusted, enter encryption password",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.",
     "Ignore": "Ignore",
     "Ignore Patterns": "Ignore Patterns",
     "Ignore Permissions": "Ignore Permissions",
@@ -282,7 +280,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Permanently add it to the ignore list, suppressing further notifications.",
     "Please consult the release notes before performing a major upgrade.": "Please consult the release notes before performing a major upgrade.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Please set a GUI Authentication User and Password in the Settings dialog.",
     "Please wait": "Please wait",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Prefix indicating that the file can be deleted if preventing directory removal",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Prefix indicating that the pattern should be matched without case sensitivity",
@@ -398,7 +395,6 @@
     "Take me back": "Take me back",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.",
     "The Syncthing Authors": "The Syncthing Authors",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "The Syncthing admin interface is configured to allow remote access without a password.",
     "The aggregated statistics are publicly available at the URL below.": "The aggregated statistics are publicly available at the URL below.",
     "The cleanup interval cannot be blank.": "The cleanup interval cannot be blank.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.",
@@ -436,7 +432,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "They are retried automatically and will be synced when the error is resolved.",
     "This Device": "This Device",
     "This Month": "This Month",
-    "This can easily give hackers access to read and change any files on your computer.": "This can easily give hackers access to read and change any files on your computer.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.",
     "This is a major version upgrade.": "This is a major version upgrade.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "This setting controls the free space required on the home (i.e., index database) disk.",
@@ -471,7 +466,6 @@
     "Use HTTPS for GUI": "Use HTTPS for GUI",
     "Use notifications from the filesystem to detect changed items.": "Use notifications from the filesystem to detect changed items.",
     "User Home": "User Home",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Username/Password has not been set for the GUI authentication. Please consider setting it up.",
     "Using a direct TCP connection over LAN": "Using a direct TCP connection over LAN",
     "Using a direct TCP connection over WAN": "Using a direct TCP connection over WAN",
     "Version": "Version",
@@ -517,6 +511,18 @@
     "modified": "modified",
     "permit": "permit",
     "seconds": "seconds",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Username/Password has not been set for the GUI authentication. Please consider setting it up.",
+            "body-2": "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.",
+            "title": "GUI Authentication: Set User and Password"
+        },
+        "warning": {
+            "body-1": "The Syncthing admin interface is configured to allow remote access without a password.",
+            "body-2": "This can easily give hackers access to read and change any files on your computer.",
+            "body-3": "Please set a GUI Authentication User and Password in the Settings dialog."
+        }
+    },
     "theme": {
         "name": {
             "black": "Black",

--- a/gui/default/assets/lang/lang-en-GB.json
+++ b/gui/default/assets/lang/lang-en-GB.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "GUI / API HTTPS Certificate",
     "GUI Authentication Password": "GUI Authentication Password",
     "GUI Authentication User": "GUI Authentication User",
-    "GUI Authentication: Set User and Password": "GUI Authentication: Set User and Password",
     "GUI Listen Address": "GUI Listen Address",
     "GUI Override Directory": "GUI Override Directory",
     "GUI Theme": "GUI Theme",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.",
     "Identification": "Identification",
     "If untrusted, enter encryption password": "If untrusted, enter encryption password",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.",
     "Ignore": "Ignore",
     "Ignore Patterns": "Ignore Patterns",
     "Ignore Permissions": "Ignore Permissions",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Permanently add it to the ignore list, suppressing further notifications.",
     "Please consult the release notes before performing a major upgrade.": "Please consult the release notes before performing a major upgrade.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Please set a GUI Authentication User and Password in the Settings dialogue.",
     "Please wait": "Please wait",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Prefix indicating that the file can be deleted if preventing directory removal",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Prefix indicating that the pattern should be matched without case sensitivity",
@@ -415,7 +412,6 @@
     "Take me back": "Take me back",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.",
     "The Syncthing Authors": "The Syncthing Authors",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "The Syncthing admin interface is configured to allow remote access without a password.",
     "The aggregated statistics are publicly available at the URL below.": "The aggregated statistics are publicly available at the URL below.",
     "The cleanup interval cannot be blank.": "The cleanup interval cannot be blank.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "They are retried automatically and will be synced when the error is resolved.",
     "This Device": "This Device",
     "This Month": "This Month",
-    "This can easily give hackers access to read and change any files on your computer.": "This can easily give hackers access to read and change any files on your computer.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.",
     "This is a major version upgrade.": "This is a major version upgrade.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "This setting controls the free space required on the home (i.e., index database) disk.",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "Use notifications from the filesystem to detect changed items.",
     "User": "User",
     "User Home": "User Home",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Username/Password has not been set for the GUI authentication. Please consider setting it up.",
     "Using a QUIC connection over LAN": "Using a QUIC connection over LAN",
     "Using a QUIC connection over WAN": "Using a QUIC connection over WAN",
     "Using a direct TCP connection over LAN": "Using a direct TCP connection over LAN",
@@ -540,6 +534,18 @@
     "modified": "modified",
     "permit": "permit",
     "seconds": "seconds",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Username/Password has not been set for the GUI authentication. Please consider setting it up.",
+            "body-2": "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.",
+            "title": "GUI Authentication: Set User and Password"
+        },
+        "warning": {
+            "body-1": "The Syncthing admin interface is configured to allow remote access without a password.",
+            "body-2": "This can easily give hackers access to read and change any files on your computer.",
+            "body-3": "Please set a GUI Authentication User and Password in the Settings dialogue."
+        }
+    },
     "theme": {
         "name": {
             "black": "Black",

--- a/gui/default/assets/lang/lang-en.json
+++ b/gui/default/assets/lang/lang-en.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "GUI / API HTTPS Certificate",
     "GUI Authentication Password": "GUI Authentication Password",
     "GUI Authentication User": "GUI Authentication User",
-    "GUI Authentication: Set User and Password": "GUI Authentication: Set User and Password",
     "GUI Listen Address": "GUI Listen Address",
     "GUI Override Directory": "GUI Override Directory",
     "GUI Theme": "GUI Theme",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.",
     "Identification": "Identification",
     "If untrusted, enter encryption password": "If untrusted, enter encryption password",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.",
     "Ignore": "Ignore",
     "Ignore Patterns": "Ignore Patterns",
     "Ignore Permissions": "Ignore Permissions",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Permanently add it to the ignore list, suppressing further notifications.",
     "Please consult the release notes before performing a major upgrade.": "Please consult the release notes before performing a major upgrade.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Please set a GUI Authentication User and Password in the Settings dialog.",
     "Please wait": "Please wait",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Prefix indicating that the file can be deleted if preventing directory removal",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Prefix indicating that the pattern should be matched without case sensitivity",
@@ -415,7 +412,6 @@
     "Take me back": "Take me back",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.",
     "The Syncthing Authors": "The Syncthing Authors",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "The Syncthing admin interface is configured to allow remote access without a password.",
     "The aggregated statistics are publicly available at the URL below.": "The aggregated statistics are publicly available at the URL below.",
     "The cleanup interval cannot be blank.": "The cleanup interval cannot be blank.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "They are retried automatically and will be synced when the error is resolved.",
     "This Device": "This Device",
     "This Month": "This Month",
-    "This can easily give hackers access to read and change any files on your computer.": "This can easily give hackers access to read and change any files on your computer.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.",
     "This is a major version upgrade.": "This is a major version upgrade.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "This setting controls the free space required on the home (i.e., index database) disk.",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "Use notifications from the filesystem to detect changed items.",
     "User": "User",
     "User Home": "User Home",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Username/Password has not been set for the GUI authentication. Please consider setting it up.",
     "Using a QUIC connection over LAN": "Using a QUIC connection over LAN",
     "Using a QUIC connection over WAN": "Using a QUIC connection over WAN",
     "Using a direct TCP connection over LAN": "Using a direct TCP connection over LAN",
@@ -540,6 +534,18 @@
     "modified": "modified",
     "permit": "permit",
     "seconds": "seconds",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Username/Password has not been set for the GUI authentication. Please consider setting it up.",
+            "body-2": "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.",
+            "title": "GUI Authentication: Set User and Password"
+        },
+        "warning": {
+            "body-1": "The Syncthing admin interface is configured to allow remote access without a password.",
+            "body-2": "This can easily give hackers access to read and change any files on your computer.",
+            "body-3": "Please set a GUI Authentication User and Password in the Settings dialog."
+        }
+    },
     "theme": {
         "name": {
             "black": "Black",

--- a/gui/default/assets/lang/lang-eo.json
+++ b/gui/default/assets/lang/lang-eo.json
@@ -137,7 +137,6 @@
     "Global State": "Malloka Stato",
     "Help": "Helpo",
     "Home page": "Hejma paĝo",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Se vi volas malhelpi aliajn uzantojn sur ĉi tiu komputilo atingi Syncthing kaj per ĝi viajn dosierojn, konsideru agordi aŭtentokontrolon.",
     "Ignore": "Ignoru",
     "Ignore Patterns": "Ignorantaj Ŝablonoj",
     "Ignore Permissions": "Ignori Permesojn",
@@ -205,7 +204,6 @@
     "Periodic scanning at given interval and enabled watching for changes": "Perioda skanado ĉe donita intervalo kaj ebligita rigardado je ŝanĝoj",
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Perioda skanado ĉe donita intervalo kaj malsukcesis agordi rigardadon je ŝanĝoj. Provante denove ĉiuminute:",
     "Please consult the release notes before performing a major upgrade.": "Bonvolu konsulti la notojn de eldono antaŭ elfari ĉefan ĝisdatigon.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Bonvolu agordi GUI Authentication Uzanto kaj Pasvorto en la agordoj dialogo.",
     "Please wait": "Bonvolu atendi",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Prefikso indikanta, ke la dosiero povas esti forigita, se ĝi malhelpas forigi dosierujon",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Prefikso indikanta, ke la ŝablono devus esti egalita usklecoblinde.",
@@ -286,7 +284,6 @@
     "Syncthing seems to be experiencing a problem processing your request. Please refresh the page or restart Syncthing if the problem persists.": "Syncthing ŝajnas renkonti problemon kun la traktado de via peto. Bonvolu refreŝigi la paĝon aŭ restarti Syncthing se la problemo daŭras.",
     "Take me back": "Prenu min reen",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "La adreso de grafika interfaco estas superregita per startigaj agordoj. Ŝanĝoj ĉi tie ne efektiviĝas dum la superrego estas aktuala.",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "La administra interfaco de Syncthing estas agordita por permesi foran atingon sen pasvorto.",
     "The aggregated statistics are publicly available at the URL below.": "La agregita statistikoj estas publike disponebla ĉe la URL malsupre.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "La agordo estis registrita sed ne aktivigita. Syncthing devas restarti por aktivigi la novan agordon.",
     "The device ID cannot be blank.": "La aparato ID ne povas esti malplena.",
@@ -311,7 +308,6 @@
     "There are no devices to share this folder with.": "Estas neniu aparato kun kiu komunigi tiun ĉi dosierujon.",
     "They are retried automatically and will be synced when the error is resolved.": "Ili estas reprovitaj aŭtomate kaj estos sinkronigitaj kiam la eraro estas solvita.",
     "This Device": "Ĉi Tiu Aparato",
-    "This can easily give hackers access to read and change any files on your computer.": "Ĉi tio povas facile doni al kodumuloj atingon por legi kaj ŝanĝi ajnajn dosierojn en via komputilo.",
     "This is a major version upgrade.": "Ĉi tio estas ĉefversio ĝisdatigita.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Ĉi tiu agordo regas la libera spaco postulita sur la hejma (t.e. indeksa datumbaza) disko.",
     "Time": "Tempo",
@@ -364,6 +360,16 @@
     "files": "dosieroj",
     "full documentation": "tuta dokumentado",
     "items": "eroj",
+    "setup-auth": {
+        "notification": {
+            "body-2": "Se vi volas malhelpi aliajn uzantojn sur ĉi tiu komputilo atingi Syncthing kaj per ĝi viajn dosierojn, konsideru agordi aŭtentokontrolon."
+        },
+        "warning": {
+            "body-1": "La administra interfaco de Syncthing estas agordita por permesi foran atingon sen pasvorto.",
+            "body-2": "Ĉi tio povas facile doni al kodumuloj atingon por legi kaj ŝanĝi ajnajn dosierojn en via komputilo.",
+            "body-3": "Bonvolu agordi GUI Authentication Uzanto kaj Pasvorto en la agordoj dialogo."
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} volas komunigi dosierujon \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} volas komunigi dosierujon \"{{folderlabel}}\" ({{folder}})."
 }

--- a/gui/default/assets/lang/lang-es.json
+++ b/gui/default/assets/lang/lang-es.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "Certificado HTTPS GUI / API",
     "GUI Authentication Password": "Contraseña de la Interfaz Gráfica de Usuario (GUI)",
     "GUI Authentication User": "Autentificación de usuario de la Interfaz Gráfica de Usuario (GUI)",
-    "GUI Authentication: Set User and Password": "Autenticación de la GUI: Establezca el Usuario y Contraseña",
     "GUI Listen Address": "Dirección de la interfaz de usuario",
     "GUI Override Directory": "Directorio de reemplazo de GUI",
     "GUI Theme": "Tema GUI",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Sin embargo, su configuración actual indica que puede no quererla activa. Hemos desactivado los informes automáticos de fallos por usted.",
     "Identification": "Identificación",
     "If untrusted, enter encryption password": "Si no es de confianza, introduzca la contraseña de cifrado",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Si desea evitar que otros usuarios de esta computadora accedan a Syncthing y, a través de él, a sus archivos, considere establecer la autenticación.",
     "Ignore": "Ignorar",
     "Ignore Patterns": "Patrones a ignorar",
     "Ignore Permissions": "Permisos a ignorar",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Escaneando periódicamente a un intervalo dado y falló la configuración para detectar cambios, volviendo a intentarlo cada 1 m:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Agregarlo permanentemente a la lista de ignorados, suprimiendo futuras notificaciones.",
     "Please consult the release notes before performing a major upgrade.": "Por favor, consultar las notas de la versión antes de realizar una actualización importante.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Por favor, introduzca un Usuario y Contraseña para la Autenticación de la Interfaz de Usuario en el panel de Ajustes.",
     "Please wait": "Por favor, espere",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Prefijo que indica que el archivo puede ser eliminado si se impide el borrado del directorio",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Prefijo que indica que el patrón debe coincidir sin distinguir mayúsculas de minúsculas",
@@ -415,7 +412,6 @@
     "Take me back": "Llévame de vuelta",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "La dirección de la Interfaz Gráfica de Ususario (GUI) está sobreescrita por las opciones de inicio. Los cambios aquí no tendrán efecto mientras la sobreescritura esté activa.",
     "The Syncthing Authors": "Los Autores de Syncthing",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "El panel de administración de Syncthing está configurado para permitir el acceso remoto sin contraseña.",
     "The aggregated statistics are publicly available at the URL below.": "Las estadísticas agragadas están disponibles públicamente en la URL de abajo.",
     "The cleanup interval cannot be blank.": "El intervalo de limpieza no puede ser nulo.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "La configuración ha sido grabada pero no activada. Syncthing debe reiniciarse para activar la nueva configuración.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Se reintentarán de forma automática y se sincronizarán cuando se resuelva el error.",
     "This Device": "Este Dispositivo",
     "This Month": "Este mes",
-    "This can easily give hackers access to read and change any files on your computer.": "Esto podría permitir fácilmente el acceso a hackers para leer y modificar cualquier fichero de tu equipo.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Este dispositivo no puede descubrir automáticamente a otros dispositivos o anunciar su propia dirección para que sea encontrado con otros. Solo dispositivos con direcciones configuradas como estáticas pueden conectarse.",
     "This is a major version upgrade.": "Hay una actualización importante.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Este ajuste controla el espacio libre necesario en el disco principal (por ejemplo, el índice de la base de datos).",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "Usar notificaciones del sistema de archivos para detectar elementos cambiados.",
     "User": "Usuario",
     "User Home": "Carpeta de inicio del usuario",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "No se ha configurado el nombre de usuario/la contraseña para la autenticación de la GUI. Por favor, considere configurarlos.",
     "Using a QUIC connection over LAN": "Usando una conexión QUIC a través de una LAN",
     "Using a QUIC connection over WAN": "Usando una conexión QUIC a través de una WAN",
     "Using a direct TCP connection over LAN": "Utilizar una conexión TCP directa a través de LAN",
@@ -540,6 +534,18 @@
     "modified": "modificado",
     "permit": "permiso",
     "seconds": "segundos",
+    "setup-auth": {
+        "notification": {
+            "body-1": "No se ha configurado el nombre de usuario/la contraseña para la autenticación de la GUI. Por favor, considere configurarlos.",
+            "body-2": "Si desea evitar que otros usuarios de esta computadora accedan a Syncthing y, a través de él, a sus archivos, considere establecer la autenticación.",
+            "title": "Autenticación de la GUI: Establezca el Usuario y Contraseña"
+        },
+        "warning": {
+            "body-1": "El panel de administración de Syncthing está configurado para permitir el acceso remoto sin contraseña.",
+            "body-2": "Esto podría permitir fácilmente el acceso a hackers para leer y modificar cualquier fichero de tu equipo.",
+            "body-3": "Por favor, introduzca un Usuario y Contraseña para la Autenticación de la Interfaz de Usuario en el panel de Ajustes."
+        }
+    },
     "theme": {
         "name": {
             "black": "Negro",

--- a/gui/default/assets/lang/lang-et.json
+++ b/gui/default/assets/lang/lang-et.json
@@ -77,7 +77,6 @@
     "Pause": "Peata",
     "Pause All": "Peata Kõik",
     "Paused": "Peatatud",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Palun seadista GUI Autentimise Kasutajatunnus ning Salasõna Seadistuste dialoogist.",
     "Please wait": "Palun oota",
     "Preview": "Eelvaade",
     "Random": "Juhuslik",
@@ -118,6 +117,11 @@
     "Use HTTPS for GUI": "Kasuta HTTPS'i GUI jaoks",
     "Version": "Versioon",
     "Yes": "Jah",
+    "setup-auth": {
+        "warning": {
+            "body-3": "Palun seadista GUI Autentimise Kasutajatunnus ning Salasõna Seadistuste dialoogist."
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} soovib jagada kausta \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} soovib jagada kausta \"{{folderlabel}}\" ({{folder}})."
 }

--- a/gui/default/assets/lang/lang-eu.json
+++ b/gui/default/assets/lang/lang-eu.json
@@ -155,7 +155,6 @@
     "GUI": "Interfaze grafikoa",
     "GUI Authentication Password": "Interfaze grafiko pasahitza",
     "GUI Authentication User": "Interfaze grafiko erabiltzaile baimendua",
-    "GUI Authentication: Set User and Password": "Interfaze grafikorako sarrera: Erabiltzailea eta pasahitza zehaztu",
     "GUI Listen Address": "Interfaze grafiko helbidea",
     "GUI Theme": "Interfaze grafiko tema",
     "General": "Orokorra",
@@ -168,7 +167,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Hala ere, zure ezarpenen arabera baliteke aktibatu nahi ez izatea. Txostenen bidalketa automatikoa desaktibatu dugu zuretzat.",
     "Identification": "Identifikazioa",
     "If untrusted, enter encryption password": "Fidagarria ez bada, idatzi enkriptatzeko pasahitza",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Ordenagailu honetako beste erabiltzaile batzuk Syncthing-era eta haren bidez zure fitxategietara sartzea eragotzi nahi baduzu, kontuan izan autentifikazioa konfiguratu behar duzula.",
     "Ignore": "Kontuan ez hartu",
     "Ignore Patterns": "Baztertzeak",
     "Ignore Permissions": "Baimenak kontuan ez hartu",
@@ -247,7 +245,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Emandako tartearen aldizkako miaketa, eta huts egin du aldaketak ikusteko ezarpenak, berriro saiatuz minuturo:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Behin betiko gehitu ezikusien zerrendara, jakinarazpen gehiago ezabatuz.",
     "Please consult the release notes before performing a major upgrade.": "Aktualizatze garrantzitsu bat egin baino lehen, bertsioaren oharrak begira itzazu.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Konfigurazio leihoan asma itzazu erabiltzale izen bat eta pasahitz bat",
     "Please wait": "Pazientzia pixka bat, otoi",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Aurrezenbaki honen bidez fitxategiak ezaba daitezke direktorioak ezabatzeko.",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Aurrizkia honek patroiak letra larririk eta minuskularik gabe bat etorri behar duela adierazten du",
@@ -344,7 +341,6 @@
     "Take me back": "Eraman nazazu atzera",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "Erabiltzailearen Interfaze Grafikoaren GUI helbidea gainidatzita dago hasierako aukerengatik. Hemengo aldaketek ez dute ondoriorik izango gainidatzi aktibo dagoen bitartean.",
     "The Syncthing Authors": "Syncthing autoreak",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Syncthing-en administrazio interfazea pentsatua da urrundikako helbideak pasahitzik gabe onartzeko !",
     "The aggregated statistics are publicly available at the URL below.": "Estadistikak zuzen bide honetan publikoki ikusgarriak dira",
     "The cleanup interval cannot be blank.": "Garbiketa tartea ez da hutsa izaiten ahal",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Konfigurazioa grabatua izan da bainan ez aktibatua. Syncthing berriz piztu behar da konfigurazio berria berriz aktibatzeko.",
@@ -377,7 +373,6 @@
     "There are no folders to share with this device.": "Ez dago gailu honekin partekatzeko karpetarik.",
     "They are retried automatically and will be synced when the error is resolved.": "Errorea zuzendua izanen delarik, automatikoki berriz entseatuak et sinkronizatuak izanen dira",
     "This Device": "Tresna hau",
-    "This can easily give hackers access to read and change any files on your computer.": "Hunek errexki irakurtzen eta aldatzen uzten ahal du zure ordenagailuko edozein fitxero, nahiz eta sartu denak ez haizu izan!",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Gailu honek ezin ditu automatikoki beste gailu batzuk aurkitu edo bere helbidea iragarri beste batzuek aurkitzeko. Estatikoki konfiguratutako helbideak dituzten gailuak bakarrik konekta daitezke.",
     "This is a major version upgrade.": "Aktualizatze garrantzitsu bat da",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Behar den espazio kontrolatzen du egokitze honek, zure erabiltzale partekatzea geritzatzen duen diskoan (hori da, indexazio datu-basean)",
@@ -406,7 +401,6 @@
     "Usage reporting is always enabled for candidate releases.": "Erabiltze estatiskitak aintzin-bertsioetan beti igorriak dira",
     "Use HTTPS for GUI": "HTTPS-a erabil ezazu GUI-arentzat",
     "Use notifications from the filesystem to detect changed items.": "Erabili fitxategi sistemaren jakinarazpenak aldatutako elementuak atzemateko",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Erabiltzaile-izena / pasahitza ez da konfiguratu interfaze grafikora sartzeko autentifikaziorako. Mesedez, konfiguratu.",
     "Version": "Bertsioa",
     "Versions": "Bertsioak",
     "Versions Path": "Bertsioen kokalekua",
@@ -440,6 +434,18 @@
     "full documentation": "Dokumentazio osoa",
     "items": "Elementuak",
     "seconds": "segunduak",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Erabiltzaile-izena / pasahitza ez da konfiguratu interfaze grafikora sartzeko autentifikaziorako. Mesedez, konfiguratu.",
+            "body-2": "Ordenagailu honetako beste erabiltzaile batzuk Syncthing-era eta haren bidez zure fitxategietara sartzea eragotzi nahi baduzu, kontuan izan autentifikazioa konfiguratu behar duzula.",
+            "title": "Interfaze grafikorako sarrera: Erabiltzailea eta pasahitza zehaztu"
+        },
+        "warning": {
+            "body-1": "Syncthing-en administrazio interfazea pentsatua da urrundikako helbideak pasahitzik gabe onartzeko !",
+            "body-2": "Hunek errexki irakurtzen eta aldatzen uzten ahal du zure ordenagailuko edozein fitxero, nahiz eta sartu denak ez haizu izan!",
+            "body-3": "Konfigurazio leihoan asma itzazu erabiltzale izen bat eta pasahitz bat"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}}k \"{{folder}}\" partekatze hontan gomitatzen zaitu.",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}}k \"{{folderlabel}}\" ({{folder}}) hontan gomitatzen zaitu.",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} -ek gailu hau birsar lezake."

--- a/gui/default/assets/lang/lang-fi.json
+++ b/gui/default/assets/lang/lang-fi.json
@@ -231,7 +231,6 @@
     "Periodic scanning at given interval and enabled watching for changes": "Ajoitettu skannaus ja muutosten seuranta päällä",
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Ajoitettu skannaus päällä. Muutosten seurannan käyttöönotto epäonnistui, yritetään uudelleen minuutin välein:",
     "Please consult the release notes before performing a major upgrade.": "Tutustu julkaisutietoihin ennen kuin teet pääversion päivityksen.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Ole hyvä ja aseta käyttäjätunnus ja salasana käyttöliittymää varten asetusvalikossa.",
     "Please wait": "Ole hyvä ja odota",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Etuliite, joka määrittää että tiedosto voidaan poistaa, mikäli se estää kansion poistamisen.",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Etuliite, joka määrittää että isot ja pienet kirjaimet eivät merkitse",
@@ -318,7 +317,6 @@
     "Syncthing seems to be experiencing a problem processing your request. Please refresh the page or restart Syncthing if the problem persists.": "Syncthing ei pysty käsittelemään pyyntöäsi. Ole hyvä ja päivitä sivu tai käynnistä Syncthing uudelleen, jos ongelma jatkuu.",
     "Take me back": "Takaisin",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "Käyttöliittymän osoite on asetettu käynnistysparametreillä. Muutokset täällä tulevat voimaan vasta, kun käynnistysparametrejä ei käytetä.",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Syncthingin hallintakäyttöliittymä on asetettu sallimaan ulkoiset yhteydet ilman salasanaa.",
     "The aggregated statistics are publicly available at the URL below.": "Koostetut tilastot ovat julkisesti saatavilla alla olevassa osoitteessa.",
     "The cleanup interval cannot be blank.": "Puhdistusväli ei voi olla tyhjä.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Asetukset on tallennettu, mutta niitä ei ole otettu käyttöön. Syncthingin täytyy käynnistyä uudelleen, jotta uudet asetukset saadaan käyttöön.",
@@ -349,7 +347,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Niiden synkronointia yritetään uudelleen automaattisesti.",
     "This Device": "Tämä laite",
     "This Month": "Tässä kuussa",
-    "This can easily give hackers access to read and change any files on your computer.": "Tämä voi helposti sallia vihamielisille tahoille pääsyn lukea ja muokata kaikkia tiedostojasi",
     "This is a major version upgrade.": "Tämä on pääversion päivitys.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Tämä asetus määrittää vaaditun vapaan levytilan kotikansiossa (se missä index-tietokanta on).",
     "Time": "Aika",
@@ -413,6 +410,13 @@
     "items": "kohteet",
     "modified": "muokattu",
     "seconds": "sekuntia",
+    "setup-auth": {
+        "warning": {
+            "body-1": "Syncthingin hallintakäyttöliittymä on asetettu sallimaan ulkoiset yhteydet ilman salasanaa.",
+            "body-2": "Tämä voi helposti sallia vihamielisille tahoille pääsyn lukea ja muokata kaikkia tiedostojasi",
+            "body-3": "Ole hyvä ja aseta käyttäjätunnus ja salasana käyttöliittymää varten asetusvalikossa."
+        }
+    },
     "theme": {
         "name": {
             "black": "Musta",

--- a/gui/default/assets/lang/lang-fil.json
+++ b/gui/default/assets/lang/lang-fil.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "Sertipiko ng HTTPS ng GUI / API",
     "GUI Authentication Password": "Password ng Authentikasyon sa GUI",
     "GUI Authentication User": "User ng Authentikasyon sa GUI",
-    "GUI Authentication: Set User and Password": "Authentikasyon sa GUI: Magtakda ng User at Password",
     "GUI Listen Address": "Listen Address ng GUI",
     "GUI Override Directory": "Override Directory ng GUI",
     "GUI Theme": "Tema ng GUI",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Gayunpaman, ang iyong kasalukuyang mga setting ay nagpapahiwatig na maaaring hindi mo ito gustong paganahin. Hindi namin pinagana ang awtomatikong pag-uulat ng pag-crash para sa iyo.",
     "Identification": "Pagkakakilanlan",
     "If untrusted, enter encryption password": "Kapag hindi pinagkakatiwalaan, ilagay ang password ng pag-encrypt",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Kung gusto mong iwasan ang ibang mga user sa computer na ito na i-access ang Syncthing at sa iyong mga file, isaalang-alang na mag-set up ng authentikasyon.",
     "Ignore": "Huwag Pansinin",
     "Ignore Patterns": "Mga Ignore Pattern",
     "Ignore Permissions": "Huwag Pansinin ang mga Pahintulot",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Ang pana-panahon na pag-scan sa ibinigay na pagitan at nabigo ang panonood sa mga pagbabago, susubukan muli bawat 1m:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Permanenteng idagdag ito sa listahan ng huwag pansinin, pinipigilan ang mga karagdagang notification.",
     "Please consult the release notes before performing a major upgrade.": "Mangyaring kumonsulta sa mga tala sa release bago magsagawa ng malaking pag-upgrade.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Mangyaring magtakda ng Authentikasyon ng GUI na User at Password sa dialog ng Mga Setting.",
     "Please wait": "Mangyaring maghintay",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Prefix na nagsasaad na ang file ay maaaring burahin kung pinipigilan ang pagbura ng direktoryo",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Prefix na nagsasaad na ang pattern ay tutugma nang walang case sensitivity",
@@ -415,7 +412,6 @@
     "Take me back": "Ibalik mo ako",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "Ang GUI address ay na-override ng mga opsyon sa pagsisimula. Ang mga pagbabago dito ay hindi magkakabisa habang ang pag-override ay nasa lugar.",
     "The Syncthing Authors": "Ang Mga Awtor ng Syncthing",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Naka-configure ang Syncthing admin interface na payagan ang remote access nang walang password.",
     "The aggregated statistics are publicly available at the URL below.": "Available nang publiko ang pinagsama-samang istatistika sa URL sa ibaba.",
     "The cleanup interval cannot be blank.": "Hindi maaring walang laman ang pagitan ng paglinis.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Na-save na ang configuration ngunit hindi naka-activate. Kailangang mag-restart ang Syncthing para i-activate ang bagong configuration.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Awtomatikong sinusubok muli ang mga ito at isi-sync kapag nalutas ang error.",
     "This Device": "Itong Device",
     "This Month": "Itong Buwan",
-    "This can easily give hackers access to read and change any files on your computer.": "Madali nitong mabibigyan ang mga hacker ng access na basahin at baguhin ang anumang mga file sa iyong computer.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Hindi awtomatikong tutuklasin ng device na ito ng mga ibang device o i-annouce ang sarili nitong address para mahanap ng iba.  Makakakonekta lamang ang mga device na may static na naka-configure na address.",
     "This is a major version upgrade.": "Ito ay isang upgrade sa major na bersyon.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Kinokontrol ng setting na ito ang kinakailangan na bakanteng espasyo sa home (hal., index database) disk.",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "Gumamit ng mga notification mula sa filesystem para mag-detect ng mga nabagong item.",
     "User": "Gumagamit",
     "User Home": "Home ng User",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Hindi nakatakda ang Username/Password para sa authentikasyon sa GUI. Isaalang-alang na i-set up.",
     "Using a QUIC connection over LAN": "Gumagamit ng QUIC na koneksyon mula sa LAN",
     "Using a QUIC connection over WAN": "Gumagamit ng QUIC na koneksyon mula sa WAN",
     "Using a direct TCP connection over LAN": "Gumagamit ng direktang TCP na koneksyon mula sa LAN",
@@ -540,6 +534,18 @@
     "modified": "binago",
     "permit": "payagan",
     "seconds": "segundo",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Hindi nakatakda ang Username/Password para sa authentikasyon sa GUI. Isaalang-alang na i-set up.",
+            "body-2": "Kung gusto mong iwasan ang ibang mga user sa computer na ito na i-access ang Syncthing at sa iyong mga file, isaalang-alang na mag-set up ng authentikasyon.",
+            "title": "Authentikasyon sa GUI: Magtakda ng User at Password"
+        },
+        "warning": {
+            "body-1": "Naka-configure ang Syncthing admin interface na payagan ang remote access nang walang password.",
+            "body-2": "Madali nitong mabibigyan ang mga hacker ng access na basahin at baguhin ang anumang mga file sa iyong computer.",
+            "body-3": "Mangyaring magtakda ng Authentikasyon ng GUI na User at Password sa dialog ng Mga Setting."
+        }
+    },
     "theme": {
         "name": {
             "black": "Itim",

--- a/gui/default/assets/lang/lang-fr-CA.json
+++ b/gui/default/assets/lang/lang-fr-CA.json
@@ -126,7 +126,6 @@
     "Pause All": "Tout suspendre",
     "Paused": "En pause",
     "Please consult the release notes before performing a major upgrade.": "Veuillez consulter les notes de version avant de réaliser une mise à jour majeure.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Veuillez définir un nom d'utilisateur et un mot de passe dans les réglages.",
     "Please wait": "Merci de patienter",
     "Preview": "Aperçu",
     "Preview Usage Report": "Aperçu du rapport de statistiques d'utilisation",
@@ -182,7 +181,6 @@
     "Syncthing is upgrading.": "Syncthing se met à jour.",
     "Syncthing seems to be down, or there is a problem with your Internet connection. Retrying…": "Syncthing semble être arrêté, ou il y a un problème avec votre connexion Internet. Nouvelle tentative ...",
     "Syncthing seems to be experiencing a problem processing your request. Please refresh the page or restart Syncthing if the problem persists.": "Syncthing semble avoir un problème pour traiter votre demande. S'il vous plaît, rafraîchissez la page ou redémarrez Syncthing si le problème persiste.",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "L'interface d'administration de Syncthing est configuré pour accepter l'accès distant sans mot de passe !",
     "The aggregated statistics are publicly available at the URL below.": "Les statistiques agrégées sont publiquement disponibles à l'adresse ci-dessous.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "La configuration a été enregistrée mais pas activée. Syncthing doit redémarrer afin d'activer la nouvelle configuration.",
     "The device ID cannot be blank.": "L'ID de l'appareil ne peut être vide.",
@@ -205,7 +203,6 @@
     "The rescan interval must be a non-negative number of seconds.": "L'intervalle d'analyse ne doit pas être un nombre négatif de secondes.",
     "They are retried automatically and will be synced when the error is resolved.": "Ils seront automatiquement retentés et synchronisés quand l'erreur sera résolue.",
     "This Device": "Cet appareil",
-    "This can easily give hackers access to read and change any files on your computer.": "Ceci peut aisément permettre à un intrus de lire et modifier n'importe quel fichier de votre ordinateur.",
     "This is a major version upgrade.": "Il s'agit d'une mise à jour majeure.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Ce réglage contrôle l'espace disque requis dans le disque qui abrite votre répertoire utilisateur (pour la base de données d'indexation).",
     "Time": "Heure",
@@ -237,6 +234,13 @@
     "files": "fichiers",
     "full documentation": "Documentation complète ici",
     "items": "éléments",
+    "setup-auth": {
+        "warning": {
+            "body-1": "L'interface d'administration de Syncthing est configuré pour accepter l'accès distant sans mot de passe !",
+            "body-2": "Ceci peut aisément permettre à un intrus de lire et modifier n'importe quel fichier de votre ordinateur.",
+            "body-3": "Veuillez définir un nom d'utilisateur et un mot de passe dans les réglages."
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} vous invite au partage \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} vous invite au partage \"{{folderlabel}}\" ({{folder}})."
 }

--- a/gui/default/assets/lang/lang-fr.json
+++ b/gui/default/assets/lang/lang-fr.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "Certificat HTTPS GUI/API",
     "GUI Authentication Password": "Mot de passe d'authentification GUI",
     "GUI Authentication User": "Utilisateur autorisé GUI",
-    "GUI Authentication: Set User and Password": "Authentification à l'interface graphique : régler nom d'utilisateur et mot de passe",
     "GUI Listen Address": "Adresse d'écoute du GUI",
     "GUI Override Directory": "Répertoire de remplacement GUI",
     "GUI Theme": "Thème graphique",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Cependant, vos réglages indiquent que vous pourriez souhaiter ne pas l'activer. Nous avons désactivé pour vous l'envoi automatique des rapports.",
     "Identification": "Identifiant abrégé",
     "If untrusted, enter encryption password": "Entrez un mot de passe pour chiffrer",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Si vous voulez empêcher d'autres utilisateurs de cet appareil à accéder à Syncthing, et via Syncthing à vos fichiers, prenez quelques secondes pour régler l'authentification.",
     "Ignore": "Refuser",
     "Ignore Patterns": "Exclusions",
     "Ignore Permissions": "Ignorer les permissions",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Analyse périodique à intervalle défini et échec d'activation de la surveillance des changements. Nouvel essai toutes les 1mn :",
     "Permanently add it to the ignore list, suppressing further notifications.": "L'ajouter à la liste des ignorés pour éviter des notifications ultérieures.",
     "Please consult the release notes before performing a major upgrade.": "Veuillez consulter les notes de version avant de réaliser une mise à jour majeure.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Veuillez définir un nom d'utilisateur et un mot de passe dans la fenêtre de Configuration.",
     "Please wait": "Merci de patienter",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Ce préfixe autorise la suppression des fichiers pour permettre la suppression de répertoires",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Ce préfixe, inutile sur Windows et Mac OS, indique que le masque d'exclusion est insensible à la casse",
@@ -415,7 +412,6 @@
     "Take me back": "Vérifier",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "L'adresse de l'interface graphique est remplacée par une ou des options de lancement. Les modifications apportées ici ne seront pas effectives tant que ces options seront utilisées.",
     "The Syncthing Authors": "Les concepteurs de Syncthing",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "L'interface d'administration de Syncthing est paramétrée pour autoriser les accès à distance sans mot de passe.",
     "The aggregated statistics are publicly available at the URL below.": "Les statistiques agrégées sont disponibles publiquement à l'adresse ci-dessous.",
     "The cleanup interval cannot be blank.": "L'intervalle de purge ne peut pas être vide.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "La configuration a été enregistrée mais pas activée. Syncthing doit redémarrer afin d'activer la nouvelle configuration.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Ils seront automatiquement retentés et synchronisés quand l'erreur sera résolue.",
     "This Device": "Cet appareil",
     "This Month": "Ce mois-ci",
-    "This can easily give hackers access to read and change any files on your computer.": "Ceci peut aisément permettre à un intrus de lire et modifier n'importe quel fichier de votre ordinateur.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Cet appareil ne peut ni découvrir automatiquement les autres, ni annoncer sa propre présence pour être découvert pas les autres. Seuls les appareils configurés avec des connexions statiques peuvent se connecter.",
     "This is a major version upgrade.": "Il s'agit d'une mise à jour majeure.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Ce réglage contrôle l'espace disque requis dans le disque qui abrite votre répertoire utilisateur (pour la base de données d'indexation).",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "Utiliser les notifications du système de fichiers pour détecter les éléments modifiés.",
     "User": "Utilisateur",
     "User Home": "Répertoire de base de l'utilisateur",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Utilisateur/Mot de passe n'ont pas été définis pour l'accès à l'interface graphique. Envisagez de le faire.",
     "Using a QUIC connection over LAN": "Connexion QUIC sur LAN",
     "Using a QUIC connection over WAN": "Connexion QUIC sur WAN",
     "Using a direct TCP connection over LAN": "Connexion TCP directe LAN",
@@ -540,6 +534,18 @@
     "modified": "modifié",
     "permit": "partager tous les attributs",
     "seconds": "secondes",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Utilisateur/Mot de passe n'ont pas été définis pour l'accès à l'interface graphique. Envisagez de le faire.",
+            "body-2": "Si vous voulez empêcher d'autres utilisateurs de cet appareil à accéder à Syncthing, et via Syncthing à vos fichiers, prenez quelques secondes pour régler l'authentification.",
+            "title": "Authentification à l'interface graphique : régler nom d'utilisateur et mot de passe"
+        },
+        "warning": {
+            "body-1": "L'interface d'administration de Syncthing est paramétrée pour autoriser les accès à distance sans mot de passe.",
+            "body-2": "Ceci peut aisément permettre à un intrus de lire et modifier n'importe quel fichier de votre ordinateur.",
+            "body-3": "Veuillez définir un nom d'utilisateur et un mot de passe dans la fenêtre de Configuration."
+        }
+    },
     "theme": {
         "name": {
             "black": "Noir",

--- a/gui/default/assets/lang/lang-fy.json
+++ b/gui/default/assets/lang/lang-fy.json
@@ -170,7 +170,6 @@
     "GUI": "GUI",
     "GUI Authentication Password": "Wachtwurd foar ferifikaasje yn GUI",
     "GUI Authentication User": "Brûkers-ID foar ferifikaasje yn GUI",
-    "GUI Authentication: Set User and Password": "GUI-ferifikaasje: Brûker en wachtwurd ynstelle",
     "GUI Listen Address": "GUI-harkadres",
     "GUI Theme": "Ynterfaasjetema",
     "General": "Algemien",
@@ -183,7 +182,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Lykwols, jo aktuele ynstellings litte sjen dat jo it miskien net oan sette wol. Wy hawwe automatysk rapportearjen fan fêstrinnen foar jo útsetten.",
     "Identification": "Identifikaasje",
     "If untrusted, enter encryption password": "As net fertroud, fier dan fersiferingswachtwurd yn",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "As jo wolle foarkomme dat oare brûkers op dizze kompjûter tagong krije ta Syncthing en dêrtroch jo bestannen, oerweeg dan it ynstellen fan ferifikaasje.",
     "Ignore": "Negearje",
     "Ignore Patterns": "Negear-patroanen",
     "Ignore Permissions": "Negear-rjochten",
@@ -254,7 +252,6 @@
     "Periodic scanning at given interval and enabled watching for changes": "Periodic scanning op opjûn ynterfal en feroarings wurde yn'e gaten hâlden.",
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Periodic scanning op opjûn ynterfal en it ynskeakeljen fan it yn'e gaten hâlden fan feroarings is mislearre, wurd eltse 1m opnij besocht:",
     "Please consult the release notes before performing a major upgrade.": "Foardat jo in wichtige fernijing ynstallearre, graach earst de fernijingsoantekenings lêze.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Graach foar GUI-ferifikaasje in brûkers-ID en wachtwurd ynstelle yn it ynstellingsdialooch.",
     "Please wait": "In amerijke",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Prefiks dy't oanjout dat de triem fourtsmiten wurde kin wannear dit it ferwiderjen belet.",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Prefiks dy't oanjout dat fergelykings mei it patroans net haadlettergefoelich wêze sille.",
@@ -343,7 +340,6 @@
     "Take me back": "Bring my werom",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "It ynterfaasje-adres waard oerskreaun troch opstart-opsjes. Feroarings wurde hjir net ynstelt wylst dizze oerskriuw-ynstelling aktyf is.",
     "The Syncthing Authors": "De Makkers fan Syncthing",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "De Syncthing haadbrûker-ynterfaasje is sa ynstelt dat tagong fan ôfstân sûnder wachtwurd tastean is.",
     "The aggregated statistics are publicly available at the URL below.": "De fersammele statistiken binnen yn it publyk beskikber fia ûndersteande keppeling.",
     "The cleanup interval cannot be blank.": "It ynterfal foar opromjen kin net leech wêze.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "De konfiguraasje is bewarre mar noch net aktivearre. Syncthing moat werstarte om de nije konfiguraasje te aktivearren.",
@@ -375,7 +371,6 @@
     "There are no folders to share with this device.": "D'r binne gjin mappen te dielen mei dit apparaat.",
     "They are retried automatically and will be synced when the error is resolved.": "Sy wurde automatysk opnij probearre en sille syngronisearre wurde wannear at de flater oplost is.",
     "This Device": "Dit Apparaat",
-    "This can easily give hackers access to read and change any files on your computer.": "Dit kin samar ynkringers (hackers) tagong jaan om elke triem op jo kompjûter te besjen en te feroarjen.",
     "This is a major version upgrade.": "Dit is in wichtige ferzjefernijing.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Dizze ynstelling bepaalt de frije romte dy't noadich is op de home-skiif (fan de yndeks-databank).",
     "Time": "Tiid",
@@ -403,7 +398,6 @@
     "Usage reporting is always enabled for candidate releases.": "Brûkersrapportaazje stiet altyd oan foar ferzje kandidaten.",
     "Use HTTPS for GUI": "Brûk HTTPS foar GUI",
     "Use notifications from the filesystem to detect changed items.": "Brûk notifikaasjes fan it triemsysteem om feroare items te detektearjen.",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Brûkersnamme / wachtwurd is net ynsteld foar de GUI-ferifikaasje. Tink der asjebleaft oer nei om dit yn te stellen.",
     "Version": "Ferzje",
     "Versions": "Ferzjes",
     "Versions Path": "Ferzjes-paad",
@@ -437,6 +431,18 @@
     "full documentation": "komplete dokumintaasje",
     "items": "items",
     "seconds": "sekonden",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Brûkersnamme / wachtwurd is net ynsteld foar de GUI-ferifikaasje. Tink der asjebleaft oer nei om dit yn te stellen.",
+            "body-2": "As jo wolle foarkomme dat oare brûkers op dizze kompjûter tagong krije ta Syncthing en dêrtroch jo bestannen, oerweeg dan it ynstellen fan ferifikaasje.",
+            "title": "GUI-ferifikaasje: Brûker en wachtwurd ynstelle"
+        },
+        "warning": {
+            "body-1": "De Syncthing haadbrûker-ynterfaasje is sa ynstelt dat tagong fan ôfstân sûnder wachtwurd tastean is.",
+            "body-2": "Dit kin samar ynkringers (hackers) tagong jaan om elke triem op jo kompjûter te besjen en te feroarjen.",
+            "body-3": "Graach foar GUI-ferifikaasje in brûkers-ID en wachtwurd ynstelle yn it ynstellingsdialooch."
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} wol map \"{{folder}}\" diele.",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} wol map \"{{folderlabel}}\" ({{folder}}) diele.",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} kin dit apparaat opnij yntrodusearje."

--- a/gui/default/assets/lang/lang-ga.json
+++ b/gui/default/assets/lang/lang-ga.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "Teastas GUI / API HTTPS",
     "GUI Authentication Password": "Pasfhocal Fíordheimhnithe GUI",
     "GUI Authentication User": "Úsáideoir Fíordheimhnithe GUI",
-    "GUI Authentication: Set User and Password": "Fíordheimhniú Grafach: Socraigh Úsáideoir agus Pasfhocal",
     "GUI Listen Address": "Seoladh Éisteachta GUI",
     "GUI Override Directory": "Comhadlann Sáraithe GUI",
     "GUI Theme": "Téama grafach",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Mar sin féin, léiríonn do shocruithe reatha go mb'fhéidir nár mhaith leat é a chumasú. Tá tuairisciú uathoibríoch tuairteála díchumasaithe againn duit.",
     "Identification": "Aitheantas",
     "If untrusted, enter encryption password": "Mura bhfuil muinín agat as, iontráil focal faire criptithe",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Más mian leat cosc a chur ar úsáideoirí eile ar an ríomhaire seo rochtain a fháil ar Syncthing agus trí do chuid comhad, smaoinigh ar fhíordheimhniú a bhunú.",
     "Ignore": "Déan neamhaird de",
     "Ignore Patterns": "Déan neamhaird de Phatrúin",
     "Ignore Permissions": "Déan neamhaird de cheadanna",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Scanadh tréimhsiúil ag eatramh áirithe agus theip ar shocrú faire le haghaidh athruithe, ag triail gach 1m:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Cuir go buan é leis an liosta neamhairde, ag cur fógraí breise faoi chois.",
     "Please consult the release notes before performing a major upgrade.": "Féach ar na nótaí scaoilte sula ndéanfaidh tú uasghrádú mór.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Socraigh Úsáideoir Fíordheimhnithe GUI agus Pasfhocal sa dialóg Socruithe.",
     "Please wait": "Fan, le do thoil",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Réimír a léiríonn gur féidir an comhad a scriosadh má chuirtear cosc ar bhaint eolaire",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Réimír a léiríonn gur chóir an patrún a mheaitseáil gan íogaireacht cáis",
@@ -415,7 +412,6 @@
     "Take me back": "Tóg ar ais mé",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "Tá an seoladh GUI sáraithe ag roghanna tosaithe. Ní thiocfaidh athruithe anseo i bhfeidhm fad is atá an sárú i bhfeidhm.",
     "The Syncthing Authors": "Na húdair sioncronaithe",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Tá an comhéadan riaracháin Syncthing cumraithe chun cianrochtain a cheadú gan phasfhocal.",
     "The aggregated statistics are publicly available at the URL below.": "Tá na staitisticí comhiomlánaithe ar fáil go poiblí ag an URL thíos.",
     "The cleanup interval cannot be blank.": "Ní féidir leis an eatramh glanta a bheith bán.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Sábháladh an chumraíocht ach níor cuireadh i ngníomh í. Ní mór sioncronú a atosú chun an chumraíocht nua a ghníomhachtú.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Déantar iad a aisghabháil go huathoibríoch agus déanfar iad a shioncronú nuair a réitítear an earráid.",
     "This Device": "An Gléas seo",
     "This Month": "An mhí seo",
-    "This can easily give hackers access to read and change any files on your computer.": "Is féidir é seo a thabhairt go héasca hackers rochtain a léamh agus aon chomhaid ar do ríomhaire a athrú.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Ní féidir leis an ngléas seo gléasanna eile a aimsiú go huathoibríoch ná a sheoladh féin a fhógairt le haimsiú ag daoine eile.  Ní féidir ach le gléasanna le seoltaí atá cumraithe go statically ceangal.",
     "This is a major version upgrade.": "Is uasghrádú mór leagan é seo.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Rialaíonn an socrú seo an spás saor in aisce a theastaíonn ar an diosca baile (i.e., bunachar sonraí innéacs).",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "Bain úsáid as fógraí ón gcóras comhad chun míreanna athraithe a bhrath.",
     "User": "Úsáideoir",
     "User Home": "Baile Úsáideora",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Níor socraíodh ainm úsáideora/pasfhocal le haghaidh fíordheimhniú an GUI. Smaoinigh, le do thoil, ar é a chur ar bun.",
     "Using a QUIC connection over LAN": "Ag baint úsáide as nasc QUIC thar LAN",
     "Using a QUIC connection over WAN": "Ag baint úsáide as nasc QUIC thar WAN",
     "Using a direct TCP connection over LAN": "Ag baint úsáide as nasc TCP díreach thar LAN",
@@ -540,6 +534,18 @@
     "modified": "modhnaithe",
     "permit": "cead",
     "seconds": "soicind",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Níor socraíodh ainm úsáideora/pasfhocal le haghaidh fíordheimhniú an GUI. Smaoinigh, le do thoil, ar é a chur ar bun.",
+            "body-2": "Más mian leat cosc a chur ar úsáideoirí eile ar an ríomhaire seo rochtain a fháil ar Syncthing agus trí do chuid comhad, smaoinigh ar fhíordheimhniú a bhunú.",
+            "title": "Fíordheimhniú Grafach: Socraigh Úsáideoir agus Pasfhocal"
+        },
+        "warning": {
+            "body-1": "Tá an comhéadan riaracháin Syncthing cumraithe chun cianrochtain a cheadú gan phasfhocal.",
+            "body-2": "Is féidir é seo a thabhairt go héasca hackers rochtain a léamh agus aon chomhaid ar do ríomhaire a athrú.",
+            "body-3": "Socraigh Úsáideoir Fíordheimhnithe GUI agus Pasfhocal sa dialóg Socruithe."
+        }
+    },
     "theme": {
         "name": {
             "black": "Dubh",

--- a/gui/default/assets/lang/lang-gl.json
+++ b/gui/default/assets/lang/lang-gl.json
@@ -144,7 +144,6 @@
     "GUI / API HTTPS Certificate": "Certificado HTTPS GUI/API",
     "GUI Authentication Password": "Contrasinal de Autenticación da GUI",
     "GUI Authentication User": "Usuario de Autenticación da GUI",
-    "GUI Authentication: Set User and Password": "Autenticación da GUI: Establecer o Usuario e o Contrasinal",
     "GUI Listen Address": "Dirección de Escoita da GUI",
     "GUI Theme": "Tema da GUI",
     "General": "Xeral",
@@ -224,7 +223,6 @@
     "Pending changes": "Cambios pendentes",
     "Permanently add it to the ignore list, suppressing further notifications.": "Engadilo permanentemente á lista de ignorados, suprimindo notificacións futuras.",
     "Please consult the release notes before performing a major upgrade.": "Por favor consulte as notas de lanzamento antes de realizar unha actualización maior.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Por favor configure un Usuario e Contrasinal de Autenticación para a GUI no diálogo de Configuración.",
     "Please wait": "Por favor espere",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Prefixo que indica que o patrón debe coincidir sen distinguir maiúsculas e minúsculas",
     "Preparing to Sync": "Preparandose para Sincronizar",
@@ -335,7 +333,6 @@
     "Take me back": "Léveme de volta",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "A dirección da GUI sobrescríbese polas opcións de arranque. Os cambios aquí non terán efecto mentres que a invalidación estea activa.",
     "The Syncthing Authors": "Os Autores de Syncthing",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "A inteface de aministración de Syncthing está configurada para permitir o acceso remoto sen ningún contrasinal.",
     "The aggregated statistics are publicly available at the URL below.": "As estatísticas agregadas son públicas na URL de debaixo.",
     "The cleanup interval cannot be blank.": "O intervalo de limpeza non pode estar en branco.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Gardouse a configuración pero non se activou. Ten que reiniciar Syncthing para activar a configuración nova.",
@@ -372,7 +369,6 @@
     "There are no folders to share with this device.": "Non hai cartafois que compartir con este dispositivo.",
     "This Device": "Este Dispositivo",
     "This Month": "Este Mes",
-    "This can easily give hackers access to read and change any files on your computer.": "Esto pode dar acceso fácil a hackers para ler e cambiar ficheiros no teu compturador.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Este dispositivo non pode descubrir outros dispositivos automaticamente ou anunciar a súa dirección a outros. So se poden contectar dispositivos con direccións estáticas configuradas.",
     "This is a major version upgrade.": "Esta é unha actualización maior.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Este axuste controla o espacio en disco dispoñible necesario no disco principal (p.ej. índice da base de datos).",
@@ -408,7 +404,6 @@
     "Use notifications from the filesystem to detect changed items.": "Utilizar notificacións do sistema de ficheiros para detectar os ficheiros cambiados.",
     "User": "Usuario",
     "User Home": "Inicio do Usuario",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Non se configuraron o usuario e contrasinal para a autenticación da GUI. Por favor considere configuralo.",
     "Using a QUIC connection over LAN": "Utilizando unha conexión QUIC en LAN",
     "Using a QUIC connection over WAN": "Utilizando unha conexión QUIC en WAN",
     "Using a direct TCP connection over LAN": "Utilizando unha conexión TCP directa en LAN",
@@ -452,6 +447,17 @@
     "modified": "modificado",
     "permit": "permitir",
     "seconds": "segundos",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Non se configuraron o usuario e contrasinal para a autenticación da GUI. Por favor considere configuralo.",
+            "title": "Autenticación da GUI: Establecer o Usuario e o Contrasinal"
+        },
+        "warning": {
+            "body-1": "A inteface de aministración de Syncthing está configurada para permitir o acceso remoto sen ningún contrasinal.",
+            "body-2": "Esto pode dar acceso fácil a hackers para ler e cambiar ficheiros no teu compturador.",
+            "body-3": "Por favor configure un Usuario e Contrasinal de Autenticación para a GUI no diálogo de Configuración."
+        }
+    },
     "theme": {
         "name": {
             "black": "Negro",

--- a/gui/default/assets/lang/lang-hi.json
+++ b/gui/default/assets/lang/lang-hi.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "GUI / API HTTPS प्रमाणपत्र",
     "GUI Authentication Password": "GUI प्रमाणीकरण पासवर्ड",
     "GUI Authentication User": "GUI प्रमाणीकरण उपयोक्ता",
-    "GUI Authentication: Set User and Password": "जीयूआई प्रमाणीकरण: उपयोक्ता और पासवर्ड निर्धारित करें",
     "GUI Listen Address": "GUI सुनने का पता",
     "GUI Override Directory": "GUI अध्यारोहण निर्देशिका",
     "GUI Theme": "GUI थीम",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "हालांकि, आपकी वर्तमान सेटिंग्स इंगित करती हैं कि आप शायद इसे सक्षम नहीं करना चाहेंगे। हमने आपके लिए स्वचालित क्रैश रिपोर्टिंग अक्षम कर दी है।",
     "Identification": "पहचान",
     "If untrusted, enter encryption password": "यदि अविश्वसनीय है, तो कूटलेखन पासवर्ड दर्ज करें",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "यदि आप इस कंप्यूटर पर अन्य उपयोक्ताओं को Syncthing और इसके माध्यम से अपनी फाइलों तक पहुँचने से रोकना चाहते हैं, तो प्रमाणीकरण स्थापित करने पर विचार करें।",
     "Ignore": "नजरअंदाज करें",
     "Ignore Patterns": "नजरअंदाज प्रतिमान",
     "Ignore Permissions": "अनुमतियां नजरअंदाज करें",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "दिए गए अंतराल पर आवधिक स्कैनिंग और परिवर्तनों को देखने के लिए स्थापना विफल, हर 1मि में पुन: प्रयास:",
     "Permanently add it to the ignore list, suppressing further notifications.": "आगे की सूचनाओं को दबाते हुए, इसे स्थायी रूप से अनदेखा सूची में जोड़ें।",
     "Please consult the release notes before performing a major upgrade.": "कृपया कोई बड़ा उन्नयन करने से पहले रिलीज़ नोट्स से परामर्श लें।",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "कृपया सेटिंग्स संवाद में एक GUI प्रमाणीकरण उपयोक्ता और पासवर्ड निर्धारित करें।",
     "Please wait": "कृपया प्रतीक्षा करें",
     "Prefix indicating that the file can be deleted if preventing directory removal": "उपसर्ग यह दर्शाता है कि निर्देशिका हटाने से रोकने पर फाइल को मिटाया जा सकता है",
     "Prefix indicating that the pattern should be matched without case sensitivity": "उपसर्ग यह दर्शाता है कि प्रतिमान को केस संवेदनशीलता के बिना मिलान किया जाना चाहिए",
@@ -415,7 +412,6 @@
     "Take me back": "मुझे वापस ले जाएं",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "GUI पता स्टार्टअप विकल्पों द्वारा अध्यारोहण किया गया है। अध्यारोहण लागू होने तक यहां परिवर्तन प्रभावी नहीं होंगे।",
     "The Syncthing Authors": "Syncthing के रचयिता",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Syncthing व्यवस्थापक इंटरफ़ेस को पासवर्ड के बिना रिमोट पहुंच की अनुमति देने के लिए विन्यस्त किया गया है।",
     "The aggregated statistics are publicly available at the URL below.": "एकत्रित आंकड़े नीचे दिए गए URL पर सार्वजनिक रूप से उपलब्ध हैं।",
     "The cleanup interval cannot be blank.": "सफाई अंतराल रिक्त नहीं हो सकता।",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "विन्यास सहेजा गया है लेकिन सक्रिय नहीं किया गया है। नए विन्यास को सक्रिय करने के लिए Syncthing को पुनरारंभ करना होगा।",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "वे स्वचालित रूप से पुनः प्रयास किए जाते हैं और त्रुटि हल होने पर समन्वयित हो जाएंगे।",
     "This Device": "यह उपकरण",
     "This Month": "इस महीने",
-    "This can easily give hackers access to read and change any files on your computer.": "इससे हैकर्स को आसानी से आपके कंप्यूटर पर किसी भी फाइल को पढ़ने और बदलने की सुविधा मिल सकती है।",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "यह उपकरण स्वचालित रूप से अन्य उपकरणों की खोज नहीं कर सकता है या दूसरों द्वारा ढूंढे जाने के लिए अपने स्वयं के पते की घोषणा नहीं कर सकता है। केवल स्थिर रूप से विन्यस्त पते वाले उपकरण ही जुड़ सकते हैं।",
     "This is a major version upgrade.": "यह प्रमुख संस्करण उन्नयन है।",
     "This setting controls the free space required on the home (i.e., index database) disk.": "यह सेटिंग होम (यानी, अनुक्रमणिका डेटाबेस) डिस्क पर आवश्यक खाली स्थान को नियंत्रित करती है।",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "परिवर्तित वस्तुओं का पता लगाने के लिए फाइल सिस्टम से सूचनाओं का उपयोग करें।",
     "User": "उपयोक्ता",
     "User Home": "उपयोक्ता होम",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "GUI प्रमाणीकरण के लिए उपयोक्तानाम/पासवर्ड निर्धारित नहीं किया गया है। कृपया इसे स्थापित करने पर विचार करें।",
     "Using a QUIC connection over LAN": "LAN पर QUIC कनेक्शन का उपयोग किया जा रहा है",
     "Using a QUIC connection over WAN": "WAN पर QUIC कनेक्शन का उपयोग किया जा रहा है",
     "Using a direct TCP connection over LAN": "LAN पर सीधे TCP कनेक्शन का उपयोग किया जा रहा है",
@@ -540,6 +534,18 @@
     "modified": "संशोधित",
     "permit": "अनुमति",
     "seconds": "सेकंड",
+    "setup-auth": {
+        "notification": {
+            "body-1": "GUI प्रमाणीकरण के लिए उपयोक्तानाम/पासवर्ड निर्धारित नहीं किया गया है। कृपया इसे स्थापित करने पर विचार करें।",
+            "body-2": "यदि आप इस कंप्यूटर पर अन्य उपयोक्ताओं को Syncthing और इसके माध्यम से अपनी फाइलों तक पहुँचने से रोकना चाहते हैं, तो प्रमाणीकरण स्थापित करने पर विचार करें।",
+            "title": "जीयूआई प्रमाणीकरण: उपयोक्ता और पासवर्ड निर्धारित करें"
+        },
+        "warning": {
+            "body-1": "Syncthing व्यवस्थापक इंटरफ़ेस को पासवर्ड के बिना रिमोट पहुंच की अनुमति देने के लिए विन्यस्त किया गया है।",
+            "body-2": "इससे हैकर्स को आसानी से आपके कंप्यूटर पर किसी भी फाइल को पढ़ने और बदलने की सुविधा मिल सकती है।",
+            "body-3": "कृपया सेटिंग्स संवाद में एक GUI प्रमाणीकरण उपयोक्ता और पासवर्ड निर्धारित करें।"
+        }
+    },
     "theme": {
         "name": {
             "black": "काली",

--- a/gui/default/assets/lang/lang-hu.json
+++ b/gui/default/assets/lang/lang-hu.json
@@ -172,7 +172,6 @@
     "GUI / API HTTPS Certificate": "GUI / API HTTPS tanúsítvány",
     "GUI Authentication Password": "Grafikus felület jelszava",
     "GUI Authentication User": "Grafikus felület felhasználói neve",
-    "GUI Authentication: Set User and Password": "Azonosítás a grafikus felületen: felhasználó és jelszó beállítása",
     "GUI Listen Address": "Grafikus felület figyelő címe",
     "GUI Override Directory": "Grafikus felület mappafelülírása",
     "GUI Theme": "Grafikus felület témája",
@@ -186,7 +185,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "A jelenlegi beállítások azonban azt jelzik, hogy nem kívánja engedélyezni. Az automatikus összeomlás-jelentés ezért letiltásra került.",
     "Identification": "Azonosítás",
     "If untrusted, enter encryption password": "Ha nem megbízható, adjon hozzá titkosítási jelszót",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Ha kívánatos, hogy a számítógép többi felhasználója ne tudja elérni a Syncthinget, sem annak fájljait, érdemes az azonosítást beállítani.",
     "Ignore": "Mellőzés",
     "Ignore Patterns": "Mellőzési minták",
     "Ignore Permissions": "Jogosultságok mellőzése",
@@ -274,7 +272,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Periodikus átnézés a megadott időközönként és a változások keresésének beállítása sikertelen, 1 percenként újrapróbálkozás:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Vegye fel véglegesen a mellőzési listára egyúttal le is tiltva a további értesítéseket.",
     "Please consult the release notes before performing a major upgrade.": "Nagyobb frissítés előtt ellenőrizni kell a kiadási megjegyzéseket.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Be kell állítani a grafikus felület felhasználónevét és jelszavát a Beállítások párbeszédablakban.",
     "Please wait": "Türelem",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Előtag, amely jelzi, hogy a fájl törölhető, ha tiltva van a mappák eltávolítása",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Előtag, amely jelzi, hogy a mintát nagy- ill. kisbetű érzékenység nélkül kell illeszteni",
@@ -390,7 +387,6 @@
     "Take me back": "Vissza",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "A grafikus felület címét az indítási beállítások felülírták. Az itt történő módosítások hatástalanok maradnak, amíg a felülírás érvényben van.",
     "The Syncthing Authors": "A Syncthing szerzői",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "A Syncthing adminisztrációs felületének távoli elérése be van kapcsolva jelszó nélkül.",
     "The aggregated statistics are publicly available at the URL below.": "Az összesített statisztikák elérhetők az alábbi címen.",
     "The cleanup interval cannot be blank.": "A tisztítási intervallum nem lehet üres.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "A beállítások elmentésre kerültek, de nem lettek aktiválva. Újra kell indítani a Syncthing-et az aktiválásukhoz.",
@@ -428,7 +424,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "A hiba javítása után automatikusan újra megpróbálja a szinkronizálást.",
     "This Device": "Ez az eszköz",
     "This Month": "Jelen hónap",
-    "This can easily give hackers access to read and change any files on your computer.": "Így a hekkerek könnyedén hozzáférést szerezhetnek a gépen tárolt fájlok olvasásához és módosításához.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Ez az eszköz nem képes automatikusan felderíteni más eszközöket, illetve nem tudja bejelenteni a saját címét, hogy mások megtalálják. Csak statikusan konfigurált címekkel rendelkező eszközök tudnak csatlakozni.",
     "This is a major version upgrade.": "Ez egy főverzió-frissítés.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Ez e beállítás szabályozza a szükséges szabad helyet a fő (pl: index, adatbázis) lemezen.",
@@ -462,7 +457,6 @@
     "Use HTTPS for GUI": "HTTPS használata a grafikus felülethez",
     "Use notifications from the filesystem to detect changed items.": "A fájlrendszer által szolgáltatott értesítések alkalmazása a megváltozott elemek keresésére.",
     "User Home": "Felhasználói kezdőlap",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Még nincs felhasználó és jelszó beállítva a grafikus felülethez. Érdemes megfontolni a beállítását.",
     "Using a direct TCP connection over LAN": "Közvetlen TCP-kapcsolat használata LAN-on keresztül",
     "Using a direct TCP connection over WAN": "Közvetlen TCP-kapcsolat használata WAN-on keresztül",
     "Version": "Verzió",
@@ -506,6 +500,18 @@
     "items": "elem",
     "modified": "módosított",
     "seconds": "másodperc",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Még nincs felhasználó és jelszó beállítva a grafikus felülethez. Érdemes megfontolni a beállítását.",
+            "body-2": "Ha kívánatos, hogy a számítógép többi felhasználója ne tudja elérni a Syncthinget, sem annak fájljait, érdemes az azonosítást beállítani.",
+            "title": "Azonosítás a grafikus felületen: felhasználó és jelszó beállítása"
+        },
+        "warning": {
+            "body-1": "A Syncthing adminisztrációs felületének távoli elérése be van kapcsolva jelszó nélkül.",
+            "body-2": "Így a hekkerek könnyedén hozzáférést szerezhetnek a gépen tárolt fájlok olvasásához és módosításához.",
+            "body-3": "Be kell állítani a grafikus felület felhasználónevét és jelszavát a Beállítások párbeszédablakban."
+        }
+    },
     "theme": {
         "name": {
             "black": "Fekete",

--- a/gui/default/assets/lang/lang-id.json
+++ b/gui/default/assets/lang/lang-id.json
@@ -169,7 +169,6 @@
     "GUI": "GUI",
     "GUI Authentication Password": "Sandi Otentikasi GUI",
     "GUI Authentication User": "Pengguna Otentikasi GUI",
-    "GUI Authentication: Set User and Password": "Otentikasi GUI: Atur Pengguna dan Sandi",
     "GUI Listen Address": "Alamat Pendengaran GUI",
     "GUI Theme": "Tema GUI",
     "General": "Umum",
@@ -182,7 +181,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Namun, pengaturan anda sekarang mengindikasi anda mungkin tidak ingin fitur diaktifkan. Kami telah menonaktifkan pelaporan crash otomatis untuk anda.",
     "Identification": "Identifikasi",
     "If untrusted, enter encryption password": "Jika tidak dipercaya, masukkan sandi enkripsi",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Jika Anda ingin mencegah pengguna lain dalam komputer ini untuk mengakses Syncthing dan melihat file Anda, pertimbangkan mengatur otentikasi.",
     "Ignore": "Abaikan",
     "Ignore Patterns": "Pola Pengabaian",
     "Ignore Permissions": "Abaikan Izin Berkas",
@@ -260,7 +258,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Pemindaian periodik pada interval tertentu dan gagal menyiapkan fitur melihat perubahan, mengulang setiap 1 menit:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Tambahkan ke daftar pengabaian secara permanen, menekan notifikasi berikutnya.",
     "Please consult the release notes before performing a major upgrade.": "Mohon lihat catatan rilis sebelum melakukan peningkatan besar.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Mohon atur sebuah pengguna dan sandi otentikasi GUI di menu Settings.",
     "Please wait": "Mohon tunggu",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Prefiks mengindikasi bahwa berkas dapat dihapus jika mencegah penghapusan direktori",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Prefiks mengindikasi bahwa pola harus dicocokkan tanpa kepekaan kapital",
@@ -357,7 +354,6 @@
     "Take me back": "Bawa saya kembali",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "Alamat GUI diambil alih oleh parameter memulai Syncthing. Perubahan disini tidak akan memiliki efek saat pengambilan alih aktif.",
     "The Syncthing Authors": "Pencipta-pencipta Syncthing",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Antarmuka admin Syncthing telah dikonfigurasi untuk mengizinkan akses jarak jauh tanpa sandi.",
     "The aggregated statistics are publicly available at the URL below.": "Pengumpulan statistik tersedia untuk umum pada URL di bawah.",
     "The cleanup interval cannot be blank.": "Interval pembersihan tidak dapat kosong.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Konfigurasi telah disimpan namun tidak diaktifkan. Syncthing harus memulai ulang untuk mengaktifkan konfigurasi baru.",
@@ -392,7 +388,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Mereka diulang secara otomatis dan akan disinkron ketika galat telah terselesaikan.",
     "This Device": "Perangkat Ini",
     "This Month": "Bulan Ini",
-    "This can easily give hackers access to read and change any files on your computer.": "Ini dapat dengan mudah memberi peretas akses untuk melihat dan mengubah file apapun dalam komputer anda.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Perangkat ini tidak dapat menemukan perangkat lain secara otomatis atau mengumumkan alamat sendiri untuk dapat ditemukan oleh perangkat lain. Hanya perangkat dengan konfigurasi alamat statik dapat menyambung.",
     "This is a major version upgrade.": "Ini adalah peningkatan versi besar.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Pengaturan ini mengontrol jumlah penyimpanan kosong yang dibutuhkan dalam penyimpanan utama (contoh database indeks).",
@@ -422,7 +417,6 @@
     "Usage reporting is always enabled for candidate releases.": "Pelaporan penggunaan selalu aktif untuk rilis kandidat.",
     "Use HTTPS for GUI": "Gunakan HTTPS untuk GUI",
     "Use notifications from the filesystem to detect changed items.": "Gunakan notifikasi dari filesistem untuk melihat perubahan berkas.",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Nama pengguna/sandi belum diatur untuk otentikasi GUI. Harap pertimbangkan menyiapkannya.",
     "Version": "Versi",
     "Versions": "Versi",
     "Versions Path": "Lokasi Versi",
@@ -457,6 +451,18 @@
     "full documentation": "dokumentasi penuh",
     "items": "berkas",
     "seconds": "detik",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Nama pengguna/sandi belum diatur untuk otentikasi GUI. Harap pertimbangkan menyiapkannya.",
+            "body-2": "Jika Anda ingin mencegah pengguna lain dalam komputer ini untuk mengakses Syncthing dan melihat file Anda, pertimbangkan mengatur otentikasi.",
+            "title": "Otentikasi GUI: Atur Pengguna dan Sandi"
+        },
+        "warning": {
+            "body-1": "Antarmuka admin Syncthing telah dikonfigurasi untuk mengizinkan akses jarak jauh tanpa sandi.",
+            "body-2": "Ini dapat dengan mudah memberi peretas akses untuk melihat dan mengubah file apapun dalam komputer anda.",
+            "body-3": "Mohon atur sebuah pengguna dan sandi otentikasi GUI di menu Settings."
+        }
+    },
     "theme": {
         "name": {
             "black": "Hitam",

--- a/gui/default/assets/lang/lang-it.json
+++ b/gui/default/assets/lang/lang-it.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "Certificati HTTPS GUI / API",
     "GUI Authentication Password": "Password dell'Interfaccia Grafica",
     "GUI Authentication User": "Utente dell'Interfaccia Grafica",
-    "GUI Authentication: Set User and Password": "Autenticazione GUI: usa utente e password",
     "GUI Listen Address": "Indirizzo dell'Interfaccia Grafica",
     "GUI Override Directory": "GUI Sostituisci Directory",
     "GUI Theme": "Tema GUI",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Tuttavia, le impostazioni correnti indicano che potresti non volerla attiva. Abbiamo disattivato la segnalazione automatica degli arresti anomali per te.",
     "Identification": "Identificazione",
     "If untrusted, enter encryption password": "Se non attendibile, immettere la password di crittografia",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Se vuoi impedire ad altri utenti di questo computer di accedere a Syncthing e attraverso di esso ai tuoi file, prendi in considerazione la configurazione dell'autenticazione.",
     "Ignore": "Ignora",
     "Ignore Patterns": "Schemi Esclusione File",
     "Ignore Permissions": "Ignora Permessi",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Scansione periodica a intervalli determinati e configurazione fallita del monitoraggio cambiamenti, nuovo tentativo ogni 1m:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Aggiungi in modo permanente all'elenco da ignorare, sopprimendo ulteriori notifiche.",
     "Please consult the release notes before performing a major upgrade.": "Si prega di consultare le note di rilascio prima di eseguire un aggiornamento principale.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Per favore impostare Utente e Password dell'Interfaccia Grafica nelle Impostazioni.",
     "Please wait": "Attendere prego",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Prefisso che indica che il file può essere eliminato se impedisce la rimozione della cartella",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Prefisso che indica che lo schema deve essere abbinato senza tener conto delle maiuscole",
@@ -415,7 +412,6 @@
     "Take me back": "Portami indietro",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "L'indirizzo della GUI è sovrascritto dalle opzioni di avvio. Le modifiche qui non avranno effetto finché queste opzioni sono impostate.",
     "The Syncthing Authors": "Autori di Syncthing",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "L'interfaccia di amministrazione di Syncthing è configurata in modo da permettere l'accesso senza password.",
     "The aggregated statistics are publicly available at the URL below.": "Le statistiche aggregate sono disponibili pubblicamente all'URL seguente.",
     "The cleanup interval cannot be blank.": "L'intervallo di pulizia non può essere vuoto.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "La configurazione è stata salvata ma non attivata. Syncthing deve essere riavviato per attivare la nuova configurazione.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Verranno effettuati tentativi in automatico e verranno sincronizzati quando l'errore sarà risolto.",
     "This Device": "Questo Dispositivo",
     "This Month": "Questo Mese",
-    "This can easily give hackers access to read and change any files on your computer.": "Ciò potrebbe facilmente permettere agli hackers accesso alla lettura e modifica di qualunque file del tuo computer.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Questo dispositivo non può rilevare automaticamente altri dispositivi o annunciare il proprio indirizzo per essere trovato da altri. Possono connettersi solo i dispositivi con indirizzi configurati staticamente.",
     "This is a major version upgrade.": "Questo è un aggiornamento di versione principale.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Questa impostazione controlla lo spazio libero richiesto sul disco home (cioè, database di indice).",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "Usa le notifiche dal filesystem per rilevare gli elementi modificati.",
     "User": "Utente",
     "User Home": "Home Utente",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Utente/password non sono stati impostati per autenticazione GUI. Considerane la configurazione.",
     "Using a QUIC connection over LAN": "Utilizza una connessione QUIC su LAN",
     "Using a QUIC connection over WAN": "Utilizza una connessione QUIC su WAN",
     "Using a direct TCP connection over LAN": "Utilizzo di una connessione TCP diretta su LAN",
@@ -540,6 +534,18 @@
     "modified": "modificato",
     "permit": "permettere",
     "seconds": "secondi",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Utente/password non sono stati impostati per autenticazione GUI. Considerane la configurazione.",
+            "body-2": "Se vuoi impedire ad altri utenti di questo computer di accedere a Syncthing e attraverso di esso ai tuoi file, prendi in considerazione la configurazione dell'autenticazione.",
+            "title": "Autenticazione GUI: usa utente e password"
+        },
+        "warning": {
+            "body-1": "L'interfaccia di amministrazione di Syncthing è configurata in modo da permettere l'accesso senza password.",
+            "body-2": "Ciò potrebbe facilmente permettere agli hackers accesso alla lettura e modifica di qualunque file del tuo computer.",
+            "body-3": "Per favore impostare Utente e Password dell'Interfaccia Grafica nelle Impostazioni."
+        }
+    },
     "theme": {
         "name": {
             "black": "Nero",

--- a/gui/default/assets/lang/lang-ja.json
+++ b/gui/default/assets/lang/lang-ja.json
@@ -152,7 +152,6 @@
     "GUI / API HTTPS Certificate": "GUI / API HTTPS証明書",
     "GUI Authentication Password": "GUI認証パスワード",
     "GUI Authentication User": "GUI認証ユーザー名",
-    "GUI Authentication: Set User and Password": "GUI認証: ユーザー名とパスワードを設定",
     "GUI Listen Address": "GUI待ち受けアドレス",
     "GUI Override Directory": "GUI上書きディレクトリ",
     "GUI Theme": "GUIテーマ",
@@ -165,7 +164,6 @@
     "Home page": "ホームページ",
     "Identification": "ID",
     "If untrusted, enter encryption password": "信頼しない場合、暗号化パスワードを入力",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "このコンピューター上の他のユーザーがSyncthingやあなたのファイルにアクセスできないようにしたい場合は、認証の設定を検討してください。",
     "Ignore": "無視",
     "Ignore Patterns": "無視するファイル名",
     "Ignore Permissions": "パーミッションを無視する",
@@ -245,7 +243,6 @@
     "Periodic scanning at given interval and disabled watching for changes": "定期スキャンは有効で変更の監視は無効です",
     "Periodic scanning at given interval and enabled watching for changes": "定期スキャンと変更の監視はいずれも有効です",
     "Please consult the release notes before performing a major upgrade.": "メジャーアップグレードを行う前にリリースノートを参照してください。",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "設定ダイアログから、GUI認証ユーザー名とパスワードを設定してください。",
     "Please wait": "お待ちください",
     "Prefix indicating that the file can be deleted if preventing directory removal": "このファイルが中に残っているためにディレクトリを削除できない場合、このファイルごと消してもよいことを示す接頭辞",
     "Prefix indicating that the pattern should be matched without case sensitivity": "大文字・小文字を同一視してマッチさせる接頭辞",
@@ -348,7 +345,6 @@
     "Take me back": "キャンセル",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "GUIアドレスはスタートアップオプションによって上書きされています。上書きが行われている間は、ここでの変更は有効になりません。",
     "The Syncthing Authors": "Syncthingの作者",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Syncthingの管理画面が、パスワードなしで外部からアクセスできるように設定されています。",
     "The aggregated statistics are publicly available at the URL below.": "集計結果は以下のURLで公開されています。",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "設定が保存されましたが、まだ有効になっていません。新しい設定を有効にするにはSyncthingを再起動してください。",
     "The device ID cannot be blank.": "デバイスIDを入力してください。",
@@ -381,7 +377,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "エラーが解決すると、自動的に再試行され同期されます。",
     "This Device": "このデバイス",
     "This Month": "今月",
-    "This can easily give hackers access to read and change any files on your computer.": "この設定のままでは、あなたのコンピューターにある任意のファイルを、他者が簡単に盗み見たり書き換えたりすることができます。",
     "This is a major version upgrade.": "メジャーアップグレードです。",
     "This setting controls the free space required on the home (i.e., index database) disk.": "この設定は、ホームディスク (インデックスデータベースがあるディスク) で必要な空き容量を管理します。",
     "Time": "日時",
@@ -410,7 +405,6 @@
     "Use HTTPS for GUI": "GUIにHTTPSを使用する",
     "Use notifications from the filesystem to detect changed items.": "ファイルシステムからの通知を使用して変更されたアイテムを検知します。",
     "User Home": "ユーザーホーム",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "GUI認証のためのユーザー名/パスワードが設定されていません。設定を検討してください。",
     "Using a direct TCP connection over LAN": "LANで直接TCP接続を使用中",
     "Using a direct TCP connection over WAN": "WANで直接TCP接続を使用中",
     "Version": "バージョン",
@@ -452,6 +446,18 @@
     "modified": "更新",
     "permit": "許可",
     "seconds": "秒",
+    "setup-auth": {
+        "notification": {
+            "body-1": "GUI認証のためのユーザー名/パスワードが設定されていません。設定を検討してください。",
+            "body-2": "このコンピューター上の他のユーザーがSyncthingやあなたのファイルにアクセスできないようにしたい場合は、認証の設定を検討してください。",
+            "title": "GUI認証: ユーザー名とパスワードを設定"
+        },
+        "warning": {
+            "body-1": "Syncthingの管理画面が、パスワードなしで外部からアクセスできるように設定されています。",
+            "body-2": "この設定のままでは、あなたのコンピューターにある任意のファイルを、他者が簡単に盗み見たり書き換えたりすることができます。",
+            "body-3": "設定ダイアログから、GUI認証ユーザー名とパスワードを設定してください。"
+        }
+    },
     "theme": {
         "name": {
             "black": "ブラック",

--- a/gui/default/assets/lang/lang-ko-KR.json
+++ b/gui/default/assets/lang/lang-ko-KR.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "GUI / API HTTPS 인증서",
     "GUI Authentication Password": "GUI 인증 비밀번호",
     "GUI Authentication User": "GUI 인증 사용자",
-    "GUI Authentication: Set User and Password": "GUI 인증: 사용자 이름과 비밀번호를 설정하십시오",
     "GUI Listen Address": "GUI 대기 주소",
     "GUI Override Directory": "GUI 덮어쓰기 폴더",
     "GUI Theme": "GUI 테마",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "다만, 현재 설정에 의하면 이 기능을 활성화하고 싶지 않을 확률이 높습니다. 따라서 자동 충돌 보고를 비활성화시켰습니다.",
     "Identification": "아이디",
     "If untrusted, enter encryption password": "신뢰하지 않으면 암호화 비밀번호를 입력하십시오",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "현재 컴퓨터의 다른 사용자로부터 Syncthing과 이를 통한 파일 접속을 차단하려면 인증을 설정하는 것이 좋습니다.",
     "Ignore": "무시",
     "Ignore Patterns": "무시 양식",
     "Ignore Permissions": "권한 무시",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "설정한 간격으로 주기적 탐색 활성화됨 및 변경 항목 감시 설정에 실패함; 1분마다 재시도 중:",
     "Permanently add it to the ignore list, suppressing further notifications.": "무시 목록에 영구 추가되어 앞으로의 알림을 차단합니다.",
     "Please consult the release notes before performing a major upgrade.": "주요 업데이트를 적용하기 전에는 출시 버전의 기록 정보를 확인하시기 바랍니다.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "설정 창에서 GUI 인증 사용자 이름과 비밀번호를 설정하십시오.",
     "Please wait": "기다려 주십시오",
     "Prefix indicating that the file can be deleted if preventing directory removal": "디렉터리 제거를 방지하는 파일을 삭제할 수 있음을 나타내는 접두사",
     "Prefix indicating that the pattern should be matched without case sensitivity": "대소문자 구분 없이 양식을 적용함을 나타내는 접두사",
@@ -415,7 +412,6 @@
     "Take me back": "뒤로",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "시작 옵션이 GUI 주소를 덮어쓰고 있습니다. 덮어쓰기가 지속되는 동안에는 설정을 변경할 수 없습니다.",
     "The Syncthing Authors": "The Syncthing Authors",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Syncthing의 관리자 인터페이스가 비밀번호 없이 원격 접속할 수 있도록 설정되어 있습니다.",
     "The aggregated statistics are publicly available at the URL below.": "수집된 통계는 아래의 주소에서 공람할 수 있습니다.",
     "The cleanup interval cannot be blank.": "정리 간격은 비워 둘 수 없습니다.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "설정이 저장되었으나 아직 활성화되지 않았습니다. 새 설정을 활성화하려면 Syncthing을 재시작하십시오.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "자동 재시도 중이며 문제가 해결되는 즉시 동기화될 예정입니다.",
     "This Device": "현재 기기",
     "This Month": "이번 달",
-    "This can easily give hackers access to read and change any files on your computer.": "이로 인해서는 해커들이 현재 컴퓨터의 모든 파일을 손쉽게 읽고 변경할 수 있게 됩니다.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "이 기기는 다른 기기를 자동으로 탐지하거나 다른 기기로부터 발견되도록 자신의 주소를 통보할 수 없습니다. 고정 주소로 설정한 기기만이 현재 기기에 접속할 수 있습니다.",
     "This is a major version upgrade.": "주요 버전 업데이트입니다.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "이 설정은 시스템(즉, 인덱스 데이터베이스가 있는) 저장 장치의 여유 공간을 관리합니다.",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "파일 시스템 알림을 사용하여 변경 항목을 감시합니다.",
     "User": "사용자",
     "User Home": "사용자 홈 폴더",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "GUI 인증을 위한 사용자 이름과 비밀번호가 설정되지 않았습니다. 이들을 설정하는 것을 고려해 주십시오.",
     "Using a QUIC connection over LAN": "QUIC 프로토콜을 이용한 근거리 통신망(LAN)을 통해 연결되어 있습니다.",
     "Using a QUIC connection over WAN": "QUIC 프로토콜을 이용한 광역 통신망(WAN)을 통해 연결되어 있습니다.",
     "Using a direct TCP connection over LAN": "TCP 프로토콜을 이용한 근거리 통신망(LAN)을 통해 직결되어 있습니다.",
@@ -540,6 +534,18 @@
     "modified": "수정됨",
     "permit": "허용",
     "seconds": "초",
+    "setup-auth": {
+        "notification": {
+            "body-1": "GUI 인증을 위한 사용자 이름과 비밀번호가 설정되지 않았습니다. 이들을 설정하는 것을 고려해 주십시오.",
+            "body-2": "현재 컴퓨터의 다른 사용자로부터 Syncthing과 이를 통한 파일 접속을 차단하려면 인증을 설정하는 것이 좋습니다.",
+            "title": "GUI 인증: 사용자 이름과 비밀번호를 설정하십시오"
+        },
+        "warning": {
+            "body-1": "Syncthing의 관리자 인터페이스가 비밀번호 없이 원격 접속할 수 있도록 설정되어 있습니다.",
+            "body-2": "이로 인해서는 해커들이 현재 컴퓨터의 모든 파일을 손쉽게 읽고 변경할 수 있게 됩니다.",
+            "body-3": "설정 창에서 GUI 인증 사용자 이름과 비밀번호를 설정하십시오."
+        }
+    },
     "theme": {
         "name": {
             "black": "검은색",

--- a/gui/default/assets/lang/lang-lt.json
+++ b/gui/default/assets/lang/lang-lt.json
@@ -171,7 +171,6 @@
     "GUI / API HTTPS Certificate": "",
     "GUI Authentication Password": "Valdymo skydelio slaptažodis",
     "GUI Authentication User": "Valdymo skydelio naudotojo vardas",
-    "GUI Authentication: Set User and Password": "Valdymo skydelio tapatybės nustatymas: Nustatyti naudotoją ir slaptažodį",
     "GUI Listen Address": "Valdymo skydelio adresas",
     "GUI Theme": "Valdymo skydelio apipavidalinimas",
     "General": "Bendra",
@@ -184,7 +183,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Vis dėlto, jūsų esami nustatymai nurodo, kad jūs, greičiausiai, nenorite turėti jas įjungtas. Mes jums išjungėme automatines ataskaitas apie strigtis.",
     "Identification": "Identifikavimas",
     "If untrusted, enter encryption password": "Jei nepatikimas, įveskite šifravimo slaptažodį",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Jei norite neleisti kitiems šio kompiuterio naudotojams gauti prieigą prie Syncthing, o per ją, prieigą prie jūsų failų, tuomet apsvarstykite galimybę nusistatyti tapatybės nustatymą.",
     "Ignore": "Nepaisyti",
     "Ignore Patterns": "Nepaisyti šablonų",
     "Ignore Permissions": "Nepaisyti failų prieigos leidimų",
@@ -271,7 +269,6 @@
     "Periodic scanning at given interval and enabled watching for changes": "Periodinis nuskaitymas nurodytu intervalu ir įjungtas pakeitimų stebėjimas",
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Periodinis nuskaitymas nurodytu intervalu ir nepavykęs nustatyti pakeitimų stebėjimas, bandoma iš naujo kas 1 min.:",
     "Please consult the release notes before performing a major upgrade.": "Peržvelkite laidos informaciją prieš atlikdami stambų atnaujinimą.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Prašome nustatymų dialoge nustatyti valdymo skydelio naudotojo vardą ir slaptažodį.",
     "Please wait": "Prašome palaukti",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Priešdelis, nurodantis, kad failas gali būti ištrintas tuo atveju, jei neleidžia šalinti katalogo",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Priešdelis, nurodantis, kad šablonas turėtų būti atitiktas neskiriant raidžių dydžio",
@@ -376,7 +373,6 @@
     "Take me back": "Sugrąžinkite mane",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "Valdymo skydelio adresas yra nustelbiamas paleidimo parametrų. Čia esantys pakeitimai neįsigalios tol, kol yra nustelbimas.",
     "The Syncthing Authors": "Syncthing autoriai",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Syncthing administratoriaus sąsaja yra sukonfigūruota taip, kad be slaptažodžio leistų nuotolinę prieigą.",
     "The aggregated statistics are publicly available at the URL below.": "Naudojimosi ataskaitą galite peržiūrėti žemiau nurodytu URL adresu.",
     "The cleanup interval cannot be blank.": "Išvalymo intervalas negali būti tuščias.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Konfigūracija įrašyta, bet neaktyvuota. Syncthing privalo būti paleista iš naujo, kad aktyvuotų naują konfigūraciją.",
@@ -411,7 +407,6 @@
     "There are no folders to share with this device.": "Nėra aplankų, kuriuos bendrinti su šiuo įrenginiu.",
     "They are retried automatically and will be synced when the error is resolved.": "Failus bus automatiškai bandoma parsiųsti dar kartą kai išspręsite klaidas.",
     "This Device": "Šis įrenginys",
-    "This can easily give hackers access to read and change any files on your computer.": "Tai gali suteikti programišiams lengvą prieigą skaityti ir keisti bet kokius failus jūsų kompiuteryje.",
     "This is a major version upgrade.": "Tai yra stambus atnaujinimas.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Šis nustatymas valdo laisvą vietą, kuri yra reikalinga namų (duomenų bazės) diske.",
     "Time": "Laikas",
@@ -443,7 +438,6 @@
     "Use HTTPS for GUI": "Valdymo skydeliui naudoti saugų ryšį ",
     "Use notifications from the filesystem to detect changed items.": "Naudoti pranešimus iš failų sistemos, norint aptikti pakeistus elementus.",
     "User": "Naudotojas",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Valdymo skydelio tapatybės nustatymui nebuvo nustatytas naudotojo vardas/slaptažodis. Apsvarstykite galimybę jį nusistatyti.",
     "Using a QUIC connection over LAN": "Naudoja QUIC ryšį per vietinį tinklą (LAN)",
     "Using a QUIC connection over WAN": "Naudoja QUIC ryšį per platųjį tinklą (WAN)",
     "Using a direct TCP connection over LAN": "Naudoja tiesioginį TCP ryšį per vietinį tinklą (LAN)",
@@ -488,6 +482,18 @@
     "items": "įrašai",
     "modified": "modifikuotas",
     "seconds": "sek.",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Valdymo skydelio tapatybės nustatymui nebuvo nustatytas naudotojo vardas/slaptažodis. Apsvarstykite galimybę jį nusistatyti.",
+            "body-2": "Jei norite neleisti kitiems šio kompiuterio naudotojams gauti prieigą prie Syncthing, o per ją, prieigą prie jūsų failų, tuomet apsvarstykite galimybę nusistatyti tapatybės nustatymą.",
+            "title": "Valdymo skydelio tapatybės nustatymas: Nustatyti naudotoją ir slaptažodį"
+        },
+        "warning": {
+            "body-1": "Syncthing administratoriaus sąsaja yra sukonfigūruota taip, kad be slaptažodžio leistų nuotolinę prieigą.",
+            "body-2": "Tai gali suteikti programišiams lengvą prieigą skaityti ir keisti bet kokius failus jūsų kompiuteryje.",
+            "body-3": "Prašome nustatymų dialoge nustatyti valdymo skydelio naudotojo vardą ir slaptažodį."
+        }
+    },
     "theme": {
         "name": {
             "black": "Juodas",

--- a/gui/default/assets/lang/lang-nb.json
+++ b/gui/default/assets/lang/lang-nb.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "GUI / API HTTPS Sertifikat",
     "GUI Authentication Password": "Passord for GUI-autenisering",
     "GUI Authentication User": "Bruker for GUI-autenisering",
-    "GUI Authentication: Set User and Password": "GUI Autentifisering: Lagre bruker og passord",
     "GUI Listen Address": "Lytteadresse for grafisk brukergrensesnitt",
     "GUI Override Directory": "GUI Overstyr katalog",
     "GUI Theme": "GUI-tema",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Imdlertid indikerer dine nåværende innstillinger at du ikke vil ha det aktivert. Vi har deaktivert automatiske krasjrapporter for deg.",
     "Identification": "Identifikasjon",
     "If untrusted, enter encryption password": "Hvis ikke sikkert, legg til krypterings-passord",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Hvis du vil hindre andre brukere på denne maskinen fra tilgang til Syncthing, og gjennom det dine filer, vurder å sette opp autentisering.",
     "Ignore": "Ignorer",
     "Ignore Patterns": "Utelatelsesmønster",
     "Ignore Permissions": "Ignorer rettigheter",
@@ -281,7 +279,6 @@
     "Periodic scanning at given interval and enabled watching for changes": "Periodisk skanning på gitte intervall og påskrudd oppsyn med endringer",
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Periodisk skanning på gitte intervall og mislyktes i å sette opp oppsyn med endringer, prøver igjen hvert minutt:",
     "Please consult the release notes before performing a major upgrade.": "Sjekk utgivelsesnotatene før en storoppgradering utføres.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Vennligst angi bruker og passord for GUI-autentisering i innstillingsvinduet.",
     "Please wait": "Vent",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Prefiks som indikerer at fila kan slettes hvis den forhindrer fjerning av mappe",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Prefiks som indikerer at mønsteret skal samsvare uten versalsensitivitet",
@@ -373,7 +370,6 @@
     "Syncthing seems to be experiencing a problem processing your request. Please refresh the page or restart Syncthing if the problem persists.": "Syncthing ser ut til å ha støtt på et problem under behandling av din forespørsel. Gjenoppfrisk nettleseren eller start Syncthing på nytt dersom problemet vedvarer.",
     "Take me back": "Gå tilbake",
     "The Syncthing Authors": "Syncthings forfattere",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Grensesnittet for administrering av Syncthing er satt til å tillate ekstern tilgang uten et passord.",
     "The aggregated statistics are publicly available at the URL below.": "Innsamlet statistikk er åpent tilgjengelig via nettadressen angitt nedenfor.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Innstillingene har blitt lagret men ikke aktivert. Syncthing må starte på ny for å aktivere de nye innstillingene.",
     "The device ID cannot be blank.": "Enhets-ID kan ikke være tom.",
@@ -401,7 +397,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Disse hentes automatisk og vil synkroniseres når feilen er blitt utbedret.",
     "This Device": "Denne enheten",
     "This Month": "Denne måned",
-    "This can easily give hackers access to read and change any files on your computer.": "Dette kan lett gi hackere tilgang til å lese og endre alle filer på datamaskinen din.",
     "This is a major version upgrade.": "Dette er en stor versjonsoppgradering.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Denne innstillingen kontrollerer ledig diskplass krevd på hjemme- (f.eks. indekseringsdatabase-) disken.",
     "Time": "Klokkeslett",
@@ -470,6 +465,17 @@
     "modified": "endret",
     "permit": "tillat",
     "seconds": "sekunder",
+    "setup-auth": {
+        "notification": {
+            "body-2": "Hvis du vil hindre andre brukere på denne maskinen fra tilgang til Syncthing, og gjennom det dine filer, vurder å sette opp autentisering.",
+            "title": "GUI Autentifisering: Lagre bruker og passord"
+        },
+        "warning": {
+            "body-1": "Grensesnittet for administrering av Syncthing er satt til å tillate ekstern tilgang uten et passord.",
+            "body-2": "Dette kan lett gi hackere tilgang til å lese og endre alle filer på datamaskinen din.",
+            "body-3": "Vennligst angi bruker og passord for GUI-autentisering i innstillingsvinduet."
+        }
+    },
     "theme": {
         "name": {
             "black": "Sort",

--- a/gui/default/assets/lang/lang-nl.json
+++ b/gui/default/assets/lang/lang-nl.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "GUI / API HTTPS-certificaat",
     "GUI Authentication Password": "GUI-wachtwoord",
     "GUI Authentication User": "GUI-gebruikersnaam",
-    "GUI Authentication: Set User and Password": "GUI-authenticatie: gebruikersnaam en wachtwoord instellen",
     "GUI Listen Address": "GUI-luisteradres",
     "GUI Override Directory": "GUI Override-map",
     "GUI Theme": "GUI-thema",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Jouw huidige instellingen geven echter aan dat je het misschien niet wil inschakelen. We hebben de automatische crashrapportage voor je uitgeschakeld.",
     "Identification": "Identificatie",
     "If untrusted, enter encryption password": "Indien niet vertrouwd, versleutelingswachtwoord opgeven",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Als je wil voorkomen dat andere gebruikers op deze computer toegang krijgen tot Syncthing en daardoor jouw bestanden, kun je overwegen om authenticatie in te stellen.",
     "Ignore": "Negeren",
     "Ignore Patterns": "Negeerpatronen",
     "Ignore Permissions": "Machtigingen negeren",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Regelmatig scannen met opgegeven interval; instellen van opvolgen van wijzigingen mislukt. Elke minuut wordt opnieuw geprobeerd:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Permanent toevoegen aan de negeerlijst zodat verdere meldingen worden onderdrukt.",
     "Please consult the release notes before performing a major upgrade.": "Lees eerst de release-opmerkingen voordat u een grote upgrade uitvoert.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Stel een gebruikersnaam en wachtwoord voor GUI-authenticatie in via het instellingen-venster.",
     "Please wait": "Even geduld",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Voorvoegsel dat aangeeft dat het bestand kan verwijderd worden als het bestand het verwijderen van een map voorkomt",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Voorvoegsel dat aangeeft dat het patroon niet hoofdlettergevoelig moet overeenkomen",
@@ -414,7 +411,6 @@
     "Take me back": "Terugkeren",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "Het GUI-adres wordt overschreven door opstart-opties. Wijzigingen hier zullen geen effect hebben terwijl de overschrijving van kracht is.",
     "The Syncthing Authors": "De Syncthing-auteurs",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "De beheerdersinterface van Syncthing is ingesteld om externe toegang zonder wachtwoord toe te staan.",
     "The aggregated statistics are publicly available at the URL below.": "De verzamelde statistieken zijn publiek beschikbaar op de onderstaande URL.",
     "The cleanup interval cannot be blank.": "Het opruiminterval mag niet leeg zijn.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "De configuratie is opslagen maar nog niet ingeschakeld. Syncthing moet opnieuw gestart worden om de nieuwe configuratie in te schakelen.",
@@ -454,7 +450,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Ze worden automatisch opnieuw geprobeerd en zullen gesynchroniseerd worden wanneer de fout opgelost is.",
     "This Device": "Dit apparaat",
     "This Month": "Deze maand",
-    "This can easily give hackers access to read and change any files on your computer.": "Dit kan hackers eenvoudig toegang geven om bestanden op je computer te lezen en te wijzigen.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Dit apparaat kan andere apparaten niet automatisch detecteren of zijn eigen adres aankondigen om door anderen gevonden te worden. Alleen apparaten met statisch geconfigureerde adressen kunnen verbinding maken.",
     "This is a major version upgrade.": "Dit is een grote versie-upgrade.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Deze instelling bepaalt de benodigde vrije ruimte op de home-schijf (d.w.z. de indexdatabase).",
@@ -490,7 +485,6 @@
     "Use notifications from the filesystem to detect changed items.": "Meldingen van het bestandssysteem gebruiken om gewijzigde items te detecteren.",
     "User": "Gebruiker",
     "User Home": "Thuismap gebruiker",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Gebruikersnaam/wachtwoord is niet ingesteld voor de GUI-authenticatie. Overweeg om het in te stellen.",
     "Using a QUIC connection over LAN": "Een QUIC-verbinding via LAN gebruiken",
     "Using a QUIC connection over WAN": "Een QUIC-verbinding via WAN gebruiken",
     "Using a direct TCP connection over LAN": "Een directe TCP-verbinding via LAN gebruiken",
@@ -539,6 +533,18 @@
     "modified": "gewijzigd",
     "permit": "toestaan",
     "seconds": "seconden",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Gebruikersnaam/wachtwoord is niet ingesteld voor de GUI-authenticatie. Overweeg om het in te stellen.",
+            "body-2": "Als je wil voorkomen dat andere gebruikers op deze computer toegang krijgen tot Syncthing en daardoor jouw bestanden, kun je overwegen om authenticatie in te stellen.",
+            "title": "GUI-authenticatie: gebruikersnaam en wachtwoord instellen"
+        },
+        "warning": {
+            "body-1": "De beheerdersinterface van Syncthing is ingesteld om externe toegang zonder wachtwoord toe te staan.",
+            "body-2": "Dit kan hackers eenvoudig toegang geven om bestanden op je computer te lezen en te wijzigen.",
+            "body-3": "Stel een gebruikersnaam en wachtwoord voor GUI-authenticatie in via het instellingen-venster."
+        }
+    },
     "theme": {
         "name": {
             "black": "Zwart",

--- a/gui/default/assets/lang/lang-nn.json
+++ b/gui/default/assets/lang/lang-nn.json
@@ -155,7 +155,6 @@
     "Pause": "Stans",
     "Paused": "Stansa",
     "Please consult the release notes before performing a major upgrade.": "Sjå utgjevingsmerknadene før ei hovudoppgradering vert utført.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Ver vennleg å laga ein GUI-brukar og eit passord i Innstillingar-dialogen.",
     "Please wait": "Gjer vel og vent",
     "Preview": "Førehandsvisning",
     "Preview Usage Report": "Førehandsvis bruksrapporten",
@@ -206,7 +205,6 @@
     "Syncthing is upgrading.": "Syncthing oppgraderer.",
     "Syncthing seems to be down, or there is a problem with your Internet connection. Retrying…": "Syncthing ser ut til å vera nede, eller så er det eit problem med nettilkoplinga di. Prøvar på ny …",
     "Syncthing seems to be experiencing a problem processing your request. Please refresh the page or restart Syncthing if the problem persists.": "Syncthing ser ut til å ha støtt på eit problem under behandling av førespurnaden din. Ver vennleg å oppfriska nettlesaren eller starta Syncthing på nytt om problemet varer ved.",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Administreringsgrensesnittet til Syncthing er sett opp til å tillata ekstern tilgang utan passord.",
     "The aggregated statistics are publicly available at the URL below.": "Samla statistikk er opent tilgjengeleg på URL-en nedanfor.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Instillingane har blitt lagra men ikkje aktivert. Syncthing må starta på ny for å aktivera dei nye instillingane.",
     "The device ID cannot be blank.": "Eining ID kan ikkje vera tom.",
@@ -229,7 +227,6 @@
     "The rescan interval must be a non-negative number of seconds.": "Talet på sekund i skanneintervallet kan ikkje vera negativt.",
     "They are retried automatically and will be synced when the error is resolved.": "Desse vil bli prøvd på nytt automatisk og vil bli synkronisert når feilen har blitt utbetra.",
     "This Device": "Denne eininga",
-    "This can easily give hackers access to read and change any files on your computer.": "Dette kan lett gje datasnokar tilgang til å lesa og endra vilkårlege filer på denne maskina.",
     "This is a major version upgrade.": "Dette er ei hovudoppgradering.",
     "Trash Can File Versioning": "Papirkorg-filutgåvehandtering",
     "Unknown": "Ukjent",
@@ -254,6 +251,13 @@
     "files": "filer",
     "full documentation": "all dokumentasjon",
     "items": "element",
+    "setup-auth": {
+        "warning": {
+            "body-1": "Administreringsgrensesnittet til Syncthing er sett opp til å tillata ekstern tilgang utan passord.",
+            "body-2": "Dette kan lett gje datasnokar tilgang til å lesa og endra vilkårlege filer på denne maskina.",
+            "body-3": "Ver vennleg å laga ein GUI-brukar og eit passord i Innstillingar-dialogen."
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} ønskjer å dela mappa \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} ønskjer å dela mappa «{{folderLabel}}» ({{folder}})."
 }

--- a/gui/default/assets/lang/lang-pl.json
+++ b/gui/default/assets/lang/lang-pl.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "Certyfikat GUI / API HTTPS",
     "GUI Authentication Password": "Hasło uwierzytelniające GUI",
     "GUI Authentication User": "Użytkownik uwierzytelniający GUI",
-    "GUI Authentication: Set User and Password": "Uwierzytelnianie GUI: ustaw nazwę użytkownika i hasło",
     "GUI Listen Address": "Adres nasłuchu GUI",
     "GUI Override Directory": "Katalog nadpisywania GUI",
     "GUI Theme": "Motyw GUI",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Niemniej jednak, obecne ustawienia wskazują, że możesz nie chcieć włączać tej funkcji. Automatyczne zgłaszanie awarii zostało więc wyłączone na tym urządzeniu.",
     "Identification": "Identyfikator",
     "If untrusted, enter encryption password": "Jeżeli folder jest niezaufany, wprowadź szyfrujące hasło",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Jeżeli chcesz zakazać innym użytkownikom tego komputera dostępu do programu Syncthing, a przez niego do swoich plików, zastanów się nad włączeniem uwierzytelniania.",
     "Ignore": "Ignoruj",
     "Ignore Patterns": "Wzorce ignorowania",
     "Ignore Permissions": "Ignorowanie uprawnień",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Okresowe skanowanie w podanym przedziale czasowym oraz nieudane ustawienie obserwowania zmian; ponawiam co minutę:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Dodaje na stałe od listy ignorowanych wyciszając kolejne powiadomienia.",
     "Please consult the release notes before performing a major upgrade.": "Prosimy zapoznać się z informacjami o wydaniu przed przeprowadzeniem dużej aktualizacji.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Ustaw nazwę użytkownika i hasło do uwierzytelniania GUI w oknie Ustawień.",
     "Please wait": "Proszę czekać",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Przedrostek wskazujący, że plik może zostać usunięty, gdy blokuje on usunięcie katalogu",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Przedrostek wskazujący, że wzorzec ma być wyszukiwany bez rozróżniania wielkości liter",
@@ -415,7 +412,6 @@
     "Take me back": "Powrót",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "Adres GUI jest nadpisywany przez opcje uruchamiania. Zmiany dokonane tutaj nie będą obowiązywać, dopóki nadpisywanie jest w użyciu.",
     "The Syncthing Authors": "Twórcy Syncthing",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Ustawienia interfejsu administracyjnego programu Syncthing zezwalają na dostęp zdalny bez hasła.",
     "The aggregated statistics are publicly available at the URL below.": "Zebrane statystyki są publicznie dostępne pod poniższym adresem.",
     "The cleanup interval cannot be blank.": "Przedział czasowy czyszczenia nie może być pusty.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Ustawienia zostały zapisane, ale nie są jeszcze aktywne. Syncthing musi zostać uruchomiony ponownie, aby aktywować nowe ustawienia.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Ponowne próby zachodzą automatycznie, a synchronizacja nastąpi po usunięciu błędu.",
     "This Device": "To urządzenie",
     "This Month": "Ten miesiąc",
-    "This can easily give hackers access to read and change any files on your computer.": "Może to umożliwić hakerom dostęp do odczytu i zmian dowolnych plików na tym komputerze.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "To urządzenie nie jest w stanie automatycznie odnajdować innych urządzeń oraz ogłaszać swojego adresu, aby mogło ono zostać znalezione przez nie. Tylko urządzenia z adresem ustawionym statycznie są w stanie się połączyć.",
     "This is a major version upgrade.": "To jest duża aktualizacja.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "To ustawienie kontroluje ilość wolnej przestrzeni na dysku domowym (np. do indeksowania bazy danych).",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "Używaj powiadomień systemu plików do wykrywania zmienionych elementów.",
     "User": "Użytkownik",
     "User Home": "Katalog domowy użytkownika",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Nazwa użytkownika i hasło do uwierzytelniania GUI nie zostały skonfigurowane. Zastanów się nad ich ustawieniem.",
     "Using a QUIC connection over LAN": "Używane jest połączenie przez protokół QUIC w sieci lokalnej LAN",
     "Using a QUIC connection over WAN": "Używane jest połączenie przez protokół QUIC w sieci rozległej WAN",
     "Using a direct TCP connection over LAN": "Używane jest bezpośrednie połączenie przez protokół TCP w sieci lokalnej LAN",
@@ -540,6 +534,18 @@
     "modified": "modyfikacja",
     "permit": "zezwól",
     "seconds": "sekundy",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Nazwa użytkownika i hasło do uwierzytelniania GUI nie zostały skonfigurowane. Zastanów się nad ich ustawieniem.",
+            "body-2": "Jeżeli chcesz zakazać innym użytkownikom tego komputera dostępu do programu Syncthing, a przez niego do swoich plików, zastanów się nad włączeniem uwierzytelniania.",
+            "title": "Uwierzytelnianie GUI: ustaw nazwę użytkownika i hasło"
+        },
+        "warning": {
+            "body-1": "Ustawienia interfejsu administracyjnego programu Syncthing zezwalają na dostęp zdalny bez hasła.",
+            "body-2": "Może to umożliwić hakerom dostęp do odczytu i zmian dowolnych plików na tym komputerze.",
+            "body-3": "Ustaw nazwę użytkownika i hasło do uwierzytelniania GUI w oknie Ustawień."
+        }
+    },
     "theme": {
         "name": {
             "black": "Czarny",

--- a/gui/default/assets/lang/lang-pt-BR.json
+++ b/gui/default/assets/lang/lang-pt-BR.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "Certificado da interface gráfica / API HTTPS",
     "GUI Authentication Password": "Senha para acesso à interface",
     "GUI Authentication User": "Nome de usuário para acesso à interface",
-    "GUI Authentication: Set User and Password": "Autenticação da GUI: Definir Usuário e Senha",
     "GUI Listen Address": "Endereço de escuta da interface web",
     "GUI Override Directory": "Pasta de substituição da interface gráfica",
     "GUI Theme": "Tema da interface",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "No entanto, suas configurações atuais indicam que você pode não querer ativá-lo. Desativamos os relatórios automáticos de falha para você.",
     "Identification": "Identificação",
     "If untrusted, enter encryption password": "Se o dispositivo não é confiável, digite a senha de criptografia",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Se você deseja impedir que outros usuários deste computador acessem o Syncthing e, por meio dele, seus arquivos, considere configurar a autenticação.",
     "Ignore": "Ignorar",
     "Ignore Patterns": "Filtros",
     "Ignore Permissions": "Ignorar permissões",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Verificação periódica habilitada no intervalo escolhido. Não foi possível configurar a verificação automática de mudanças, tentando novamente a cada 1 minuto:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Adicione-o permanentemente à lista de ignorados, suprimindo notificações futuras.",
     "Please consult the release notes before performing a major upgrade.": "Por favor, consulte as notas de lançamento antes de atualizar para uma versão \"major\".",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Por favor, defina um nome de usuário e senha para acesso à interface web, nas configurações.",
     "Please wait": "Aguarde",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Prefixo indicando que o arquivo pode ser removido caso esteja impedindo a remoção do seu diretório",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Prefixo indicando que o filtro deve ser igualado sem distinção entre maiúsculas e minúsculas",
@@ -415,7 +412,6 @@
     "Take me back": "Tire-me daqui",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "O endereço da GUI é substituído pelas opções de inicialização. As alterações aqui não terão efeito enquanto a substituição estiver em vigor.",
     "The Syncthing Authors": "Autores do Syncthing",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "A interface de administração do Syncthing está configurada para permitir acesso remoto sem uma senha.",
     "The aggregated statistics are publicly available at the URL below.": "As estatísticas agregadas estão disponíveis no endereço abaixo.",
     "The cleanup interval cannot be blank.": "O intervalo de limpeza não pode estar em branco.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "A configuração foi salva mas ainda não foi ativada. O Syncthing precisa ser reiniciado para a ativação da nova configuração.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Serão tentadas automaticamente e sincronizadas após o erro ter sido resolvido.",
     "This Device": "Este dispositivo",
     "This Month": "Este mês",
-    "This can easily give hackers access to read and change any files on your computer.": "Isto pode dar a hackers poder de leitura e escrita de qualquer arquivo em seu dispositivo.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Este dispositivo não pode descobrir automaticamente outros dispositivos ou anunciar seu próprio endereço para ser encontrado por outros. Apenas dispositivos com endereços configurados estaticamente podem se conectar.",
     "This is a major version upgrade.": "Esta é uma atualização para uma versão \"major\".",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Este ajuste controla o espaço livre necessário no disco que contém o banco de dados do Syncthing.",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "Usar notificações do sistema de ficheiros para detectar itens alterados.",
     "User": "Usuário",
     "User Home": "Pasta do usuário",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "O Usuário/Senha não foi definido para a autenticação da GUI. Por favor, considere defini-los.",
     "Using a QUIC connection over LAN": "Usando conexão QUIC sobre LAN",
     "Using a QUIC connection over WAN": "Usando conexão QUIC sobre WAN",
     "Using a direct TCP connection over LAN": "Usando uma conexão TCP direta via LAN",
@@ -540,6 +534,18 @@
     "modified": "modificado",
     "permit": "permitir",
     "seconds": "segundos",
+    "setup-auth": {
+        "notification": {
+            "body-1": "O Usuário/Senha não foi definido para a autenticação da GUI. Por favor, considere defini-los.",
+            "body-2": "Se você deseja impedir que outros usuários deste computador acessem o Syncthing e, por meio dele, seus arquivos, considere configurar a autenticação.",
+            "title": "Autenticação da GUI: Definir Usuário e Senha"
+        },
+        "warning": {
+            "body-1": "A interface de administração do Syncthing está configurada para permitir acesso remoto sem uma senha.",
+            "body-2": "Isto pode dar a hackers poder de leitura e escrita de qualquer arquivo em seu dispositivo.",
+            "body-3": "Por favor, defina um nome de usuário e senha para acesso à interface web, nas configurações."
+        }
+    },
     "theme": {
         "name": {
             "black": "Preto",

--- a/gui/default/assets/lang/lang-pt-PT.json
+++ b/gui/default/assets/lang/lang-pt-PT.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "Certificado da interface gráfica / API HTTPS",
     "GUI Authentication Password": "Senha da autenticação na interface gráfica",
     "GUI Authentication User": "Utilizador da autenticação na interface gráfica",
-    "GUI Authentication: Set User and Password": "Autenticação na interface gráfica: Definir utilizador e senha",
     "GUI Listen Address": "Endereço de escuta da interface gráfica",
     "GUI Override Directory": "Pasta de substituição da interface gráfica",
     "GUI Theme": "Tema gráfico",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Contudo, a sua configuração atual indica que pode não a querer ativada. Nós desativámos automaticamente o relatório de falhas para si.",
     "Identification": "Identificação",
     "If untrusted, enter encryption password": "Se não for fiável, insira uma senha de encriptação",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Se quiser evitar que outros utilizadores neste computador acedam ao Syncthing e, através dele, aos seus ficheiros, considere configurar a autenticação.",
     "Ignore": "Ignorar",
     "Ignore Patterns": "Padrões de exclusão",
     "Ignore Permissions": "Ignorar permissões",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Verificação periódica no intervalo dado e falha ao preparar a vigilância de alterações, tentando novamente a cada minuto:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Adicionar permanentemente à lista de ignorados, inibindo novas notificações.",
     "Please consult the release notes before performing a major upgrade.": "Consulte as notas de lançamento antes de fazer uma actualização importante.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Por favor, defina um utilizador e senha de autenticação para a interface gráfica, nas configurações.",
     "Please wait": "Aguarde",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Prefixo para indicar que o ficheiro pode ser eliminado se estiver a impedir a eliminação da pasta",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Prefixo para indicar que o padrão não diferencia entre maiúsculas e minúsculas",
@@ -415,7 +412,6 @@
     "Take me back": "Voltar atrás",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "O endereço da interface gráfica é substituído pelas opções de arranque. Alterações feitas aqui não terão efeito enquanto a substituição estiver ativa.",
     "The Syncthing Authors": "Os autores do Syncthing",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "A interface de administração do Syncthing está configurada para permitir o acesso remoto sem pedir senha.",
     "The aggregated statistics are publicly available at the URL below.": "As estatísticas agregadas estão publicamente disponíveis no URL abaixo.",
     "The cleanup interval cannot be blank.": "O intervalo entre limpezas não pode estar vazio.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "A configuração foi gravada mas não ativada. O Syncthing tem que reiniciar para ativar a nova configuração.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Será tentado automaticamente e os itens serão sincronizados assim que o erro seja resolvido.",
     "This Device": "Este dispositivo",
     "This Month": "Este mês",
-    "This can easily give hackers access to read and change any files on your computer.": "Isso facilmente dará acesso aos piratas informáticos para lerem e modificarem quaisquer ficheiros no seu computador.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Este dispositivo não pode descobrir automaticamente outros dispositivos ou anunciar o seu próprio endereço para que seja encontrado pelos outros. Apenas dispositivos com endereços configurados estaticamente podem estabelecer ligação.",
     "This is a major version upgrade.": "Esta é uma atualização para uma versão importante.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Este parâmetro controla o espaço livre necessário no disco base (ou seja, o disco da base de dados do índice).",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "Usar notificações do sistema de ficheiros para detectar itens alterados.",
     "User": "Utilizador",
     "User Home": "Pasta do utilizador",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "O nome de utilizador e a respectiva senha para a autenticação na interface gráfica não foram definidos. Considere efectuar essa configuração.",
     "Using a QUIC connection over LAN": "Usando uma ligação QUIC sobre LAN",
     "Using a QUIC connection over WAN": "Usando uma ligação QUIC sobre WAN",
     "Using a direct TCP connection over LAN": "Usando uma ligação TCP directa sobre LAN",
@@ -540,6 +534,18 @@
     "modified": "modificado",
     "permit": "permitir",
     "seconds": "segundos",
+    "setup-auth": {
+        "notification": {
+            "body-1": "O nome de utilizador e a respectiva senha para a autenticação na interface gráfica não foram definidos. Considere efectuar essa configuração.",
+            "body-2": "Se quiser evitar que outros utilizadores neste computador acedam ao Syncthing e, através dele, aos seus ficheiros, considere configurar a autenticação.",
+            "title": "Autenticação na interface gráfica: Definir utilizador e senha"
+        },
+        "warning": {
+            "body-1": "A interface de administração do Syncthing está configurada para permitir o acesso remoto sem pedir senha.",
+            "body-2": "Isso facilmente dará acesso aos piratas informáticos para lerem e modificarem quaisquer ficheiros no seu computador.",
+            "body-3": "Por favor, defina um utilizador e senha de autenticação para a interface gráfica, nas configurações."
+        }
+    },
     "theme": {
         "name": {
             "black": "Preto",

--- a/gui/default/assets/lang/lang-ro-RO.json
+++ b/gui/default/assets/lang/lang-ro-RO.json
@@ -167,7 +167,6 @@
     "GUI": "GUI",
     "GUI Authentication Password": "Parolă Interfaţă",
     "GUI Authentication User": "User Interfaţă",
-    "GUI Authentication: Set User and Password": "GUI Authentication: Set User and Password",
     "GUI Listen Address": "GUI Listen Address",
     "GUI Theme": "GUI Theme",
     "General": "General",
@@ -180,7 +179,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.",
     "Identification": "Identification",
     "If untrusted, enter encryption password": "If untrusted, enter encryption password",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.",
     "Ignore": "Ignoră",
     "Ignore Patterns": "Reguli de excludere",
     "Ignore Permissions": "Ignoră Permisiuni",
@@ -252,7 +250,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Permanently add it to the ignore list, suppressing further notifications.",
     "Please consult the release notes before performing a major upgrade.": "Please consult the release notes before performing a major upgrade.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Please set a GUI Authentication User and Password in the Settings dialog.",
     "Please wait": "Aşteaptă",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Prefix indicating that the file can be deleted if preventing directory removal",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Prefix indicating that the pattern should be matched without case sensitivity",
@@ -347,7 +344,6 @@
     "Take me back": "Take me back",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.",
     "The Syncthing Authors": "The Syncthing Authors",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "The Syncthing admin interface is configured to allow remote access without a password.",
     "The aggregated statistics are publicly available at the URL below.": "The aggregated statistics are publicly available at the URL below.",
     "The cleanup interval cannot be blank.": "The cleanup interval cannot be blank.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Configuraţia a fost salvată dar nu şi activată. Syncthing trebuie să repornească pentru a activa noua configuraţie.",
@@ -380,7 +376,6 @@
     "There are no folders to share with this device.": "There are no folders to share with this device.",
     "They are retried automatically and will be synced when the error is resolved.": "They are retried automatically and will be synced when the error is resolved.",
     "This Device": "This Device",
-    "This can easily give hackers access to read and change any files on your computer.": "This can easily give hackers access to read and change any files on your computer.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.",
     "This is a major version upgrade.": "This is a major version upgrade.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "This setting controls the free space required on the home (i.e., index database) disk.",
@@ -408,7 +403,6 @@
     "Uptime": "Uptime",
     "Usage reporting is always enabled for candidate releases.": "Usage reporting is always enabled for candidate releases.",
     "Use HTTPS for GUI": "Foloseşte HTTPS pentru interfaţă",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Username/Password has not been set for the GUI authentication. Please consider setting it up.",
     "Version": "Versiune",
     "Versions": "Versions",
     "Versions Path": "Locaţie Versiuni",
@@ -442,6 +436,18 @@
     "full documentation": "toată documentaţia",
     "items": "obiecte",
     "seconds": "seconds",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Username/Password has not been set for the GUI authentication. Please consider setting it up.",
+            "body-2": "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.",
+            "title": "GUI Authentication: Set User and Password"
+        },
+        "warning": {
+            "body-1": "The Syncthing admin interface is configured to allow remote access without a password.",
+            "body-2": "This can easily give hackers access to read and change any files on your computer.",
+            "body-3": "Please set a GUI Authentication User and Password in the Settings dialog."
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{Dispozitivul}} vrea să transmită mapa {{Mapa}}",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} wants to share folder \"{{folderlabel}}\" ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} might reintroduce this device."

--- a/gui/default/assets/lang/lang-ru.json
+++ b/gui/default/assets/lang/lang-ru.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "HTTPS-сертификат GUI/API",
     "GUI Authentication Password": "Пароль для доступа к панели управления",
     "GUI Authentication User": "Имя пользователя для доступа к панели управления",
-    "GUI Authentication: Set User and Password": "GUI аутентификация: Установите имя пользователя и пароль",
     "GUI Listen Address": "Адрес GUI",
     "GUI Override Directory": "Каталог переопределения графического интерфейса",
     "GUI Theme": "Тема оформления",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Ваши настройки указывают что вы не хотите, чтобы эта функция была включена. Мы отключили отправку отчетов о сбоях.",
     "Identification": "Идентификация",
     "If untrusted, enter encryption password": "Если ненадёжное, укажите пароль шифрования",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Если вы хотите запретить другим пользователям на этом компьютере доступ к Syncthing и через него к вашим файлам, подумайте о настройке аутентификации.",
     "Ignore": "Игнорировать",
     "Ignore Patterns": "Шаблоны игнорирования",
     "Ignore Permissions": "Игнорировать файловые права доступа",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Периодическое сканирование с заданным интервалом, неудачная настройка отслеживания изменений, повторная попытка каждую минуту:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Добавление в список игнорирования навсегда с подавлением будущих уведомлений.",
     "Please consult the release notes before performing a major upgrade.": "Перед проведением обновления основной версии ознакомьтесь, пожалуйста, с замечаниями к версии.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Установите имя пользователя и пароль для интерфейса в настройках.",
     "Please wait": "Пожалуйста, подождите",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Префикс, указывающий что файл может быть удалён, если он мешает удалить папку",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Префикс, указывающий что шаблон должен сопоставляться без учёта регистра",
@@ -415,7 +412,6 @@
     "Take me back": "Вернуться к редактированию",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "Эти изменения не вступят в силу, пока адрес панели управления переопределён в настройках запуска.",
     "The Syncthing Authors": "Авторы Syncthing",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Административный интерфейс Syncthing настроен для предоставления удаленного доступа без пароля.",
     "The aggregated statistics are publicly available at the URL below.": "Агрегированные статистические данные общедоступны по ссылке ниже.",
     "The cleanup interval cannot be blank.": "Интервал очистки должен быть заполнен.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Конфигурация была сохранена, но не активирована. Syncthing должен быть перезапущен для применения новой конфигурации.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Будут синхронизированы автоматически когда ошибка будет исправлена.",
     "This Device": "Это устройство",
     "This Month": "Этот месяц",
-    "This can easily give hackers access to read and change any files on your computer.": "Это может дать доступ хакерам для чтения и изменения любых файлов на вашем компьютере.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Это устройство не может автоматически обнаруживать другие устройства или анонсировать свой адрес для обнаружения извне. Только устройства со статически заданными адресами могут подключиться.",
     "This is a major version upgrade.": "Это обновление основной версии продукта.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Эта настройка управляет свободным местом, необходимым на домашнем диске (например, для базы индексов).",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "Использовать уведомления от файловой системы для обнаружения изменённых объектов.",
     "User": "Пользователь",
     "User Home": "Папка пользователя",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Имя пользователя/пароль не был установлен для GUI-аутентификации. Настройте его.",
     "Using a QUIC connection over LAN": "Использовать QUIC-соединения в LAN",
     "Using a QUIC connection over WAN": "Использовать QUIC-соединения в WAN",
     "Using a direct TCP connection over LAN": "Использовать прямые TCP-соединения в LAN",
@@ -540,6 +534,18 @@
     "modified": "изменено",
     "permit": "разрешить",
     "seconds": "сек.",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Имя пользователя/пароль не был установлен для GUI-аутентификации. Настройте его.",
+            "body-2": "Если вы хотите запретить другим пользователям на этом компьютере доступ к Syncthing и через него к вашим файлам, подумайте о настройке аутентификации.",
+            "title": "GUI аутентификация: Установите имя пользователя и пароль"
+        },
+        "warning": {
+            "body-1": "Административный интерфейс Syncthing настроен для предоставления удаленного доступа без пароля.",
+            "body-2": "Это может дать доступ хакерам для чтения и изменения любых файлов на вашем компьютере.",
+            "body-3": "Установите имя пользователя и пароль для интерфейса в настройках."
+        }
+    },
     "theme": {
         "name": {
             "black": "Чёрная",

--- a/gui/default/assets/lang/lang-si.json
+++ b/gui/default/assets/lang/lang-si.json
@@ -169,7 +169,6 @@
     "GUI / API HTTPS Certificate": "GUI / යෙ.ක්‍ර.මු. HTTPS සහතිකය",
     "GUI Authentication Password": "GUI සත්‍යාපන මුරපදය",
     "GUI Authentication User": "GUI සත්‍යාපන පරිශ්‍රීලක",
-    "GUI Authentication: Set User and Password": "GUI සත්‍යාපනය: පරිශ්‍රීලක හා මුරපදය සකසන්න",
     "GUI Listen Address": "GUI සවන්දීමේ ලිපිනය",
     "GUI Override Directory": "GUI අභිබවන නාමාවලිය",
     "GUI Theme": "GUI තේමාව",
@@ -183,7 +182,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "කෙසේ වෙතත්, ඔබගේ වත්මන් සැකසුම් පෙන්නුම් කරන්නේ ඔබට එය සක්‍රිය කිරීමට අවශ්‍ය නොවිය හැකි බවයි. අපි ඔබ වෙනුවෙන් ස්වයංක්‍රීය බිඳ වැටීම් වාර්තා කිරීම අබල කර ඇත.",
     "Identification": "හැඳුනුම",
     "If untrusted, enter encryption password": "විශ්වාස කළ නොහැකි නම්, සංකේතාංකන මුරපදය ඇතුළත් කරන්න",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "ඔබට මෙම පරිගණකයේ අනෙකුත් පරිශීලකයින් සමමුහුර්තකරණයට සහ ඒ හරහා ඔබගේ ගොනු වලට ප්‍රවේශ වීම වැලැක්වීමට අවශ්‍ය නම්, සත්‍යාපනය සැකසීම සලකා බලන්න.",
     "Ignore": "නොසලකන්න",
     "Ignore Patterns": "රටා නොසලකා හරින්න",
     "Ignore Permissions": "අවසර නොසලකන්න",
@@ -272,7 +270,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "ලබා දී ඇති කාල පරතරයකදී වරින් වර ස්කෑන් කිරීම සහ වෙනස්කම් සඳහා නැරඹීම පිහිටුවීම අසාර්ථක විය, සෑම මීටර 1කට වරක් නැවත උත්සාහ කිරීම:",
     "Permanently add it to the ignore list, suppressing further notifications.": "තවදුරටත් දැනුම්දීම් යටපත් කරමින් එය නොසලකා හැරීමේ ලැයිස්තුවට ස්ථිරව එක් කරන්න.",
     "Please consult the release notes before performing a major upgrade.": "ප්‍රධාන උත්ශ්‍රේණි කිරීමක් සිදු කිරීමට පෙර කරුණාකර නිකුතු සටහන් බලන්න.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "කරුණාකර සැකසීම් සංවාදයේ GUI සත්‍යාපන පරිශීලකයෙකු සහ මුරපදයක් සකසන්න.",
     "Please wait": "රැඳෙන්න",
     "Prefix indicating that the file can be deleted if preventing directory removal": "නාමාවලිය ඉවත් කිරීම වළක්වන්නේ නම් ගොනුව මකා දැමිය හැකි බව පෙන්නුම් කරන උපසර්ගය",
     "Prefix indicating that the pattern should be matched without case sensitivity": "සංවේදිතාවකින් තොරව රටාව ගැලපිය යුතු බව පෙන්නුම් කරන උපසර්ගය",
@@ -383,7 +380,6 @@
     "Take me back": "මාව ආපසු ගන්න",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "GUI ලිපිනය ආරම්භක විකල්ප මගින් අභිබවා යයි. ප්‍රතික්‍ෂේප කිරීම ක්‍රියාත්මක වන විට මෙහි වෙනස්කම් බල නොපායි.",
     "The Syncthing Authors": "සයින්තින් කතුවරුන්",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "මුරපදයක් නොමැතිව දුරස්ථ ප්‍රවේශය සඳහා සමමුහුර්ත කිරීමේ පරිපාලක අතුරුමුහුණත වින්‍යාස කර ඇත.",
     "The aggregated statistics are publicly available at the URL below.": "එකතු කළ සංඛ්‍යාලේඛන පහත URL හි ප්‍රසිද්ධියේ ලබා ගත හැකිය.",
     "The cleanup interval cannot be blank.": "පිරිසිදු කිරීමේ පරතරය හිස් විය නොහැක.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "වින්‍යාසය සුරකින ලද නමුත් සක්‍රිය කර නැත. නව වින්‍යාසය සක්‍රිය කිරීමට සමමුහුර්ත කිරීම නැවත ආරම්භ කළ යුතුය.",
@@ -421,7 +417,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "ඒවා ස්වයංක්‍රීයව නැවත උත්සාහ කරන අතර දෝෂය නිරාකරණය වූ විට සමමුහුර්ත වේ.",
     "This Device": "මෙම උපාංගය",
     "This Month": "මේ මාසයේ",
-    "This can easily give hackers access to read and change any files on your computer.": "මෙය හැකර්වරුන්ට ඔබේ පරිගණකයේ ඇති ඕනෑම ගොනුවක් කියවීමට සහ වෙනස් කිරීමට පහසුවෙන් ප්‍රවේශය ලබා දිය හැක.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "මෙම උපාංගයට වෙනත් උපාංග ස්වයංක්‍රීයව සොයා ගැනීමට හෝ වෙනත් අය විසින් සොයා ගැනීමට එහිම ලිපිනය ප්‍රකාශ කිරීමට නොහැකිය. සම්බන්ධ විය හැක්කේ ස්ථිතිකව වින්‍යාස කළ ලිපින සහිත උපාංගවලට පමණි.",
     "This is a major version upgrade.": "මෙය ප්රධාන අනුවාදය උත්ශ්රේණි කිරීමකි.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "මෙම සිටුවම නිවසේ (එනම්, දර්ශක දත්ත ගබඩාව) තැටියේ අවශ්‍ය නිදහස් ඉඩ පාලනය කරයි.",
@@ -454,7 +449,6 @@
     "Usage reporting is always enabled for candidate releases.": "අපේක්ෂක නිකුතු සඳහා භාවිත වාර්තා කිරීම සැමවිටම සක්‍රීය කර ඇත.",
     "Use HTTPS for GUI": "GUI සඳහා HTTPS භාවිතා කරන්න",
     "Use notifications from the filesystem to detect changed items.": "වෙනස් කළ අයිතම හඳුනා ගැනීමට ගොනු පද්ධතියෙන් දැනුම්දීම් භාවිතා කරන්න.",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "GUI සත්‍යාපනය සඳහා පරිශීලක නාමය/මුරපදය සකසා නොමැත. කරුණාකර එය පිහිටුවීම සලකා බලන්න.",
     "Using a QUIC connection over LAN": "LAN හරහා QUIC සම්බන්ධතාවයක් භාවිතය",
     "Using a QUIC connection over WAN": "WAN හරහා QUIC සම්බන්ධතාවයක් භාවිතය",
     "Using a direct TCP connection over LAN": "LAN හරහා සෘජු TCP සම්බන්ධතාවයක් භාවිතය",
@@ -502,6 +496,18 @@
     "modified": "සංශෝධිතයි",
     "permit": "අවසරය",
     "seconds": "තත්පර",
+    "setup-auth": {
+        "notification": {
+            "body-1": "GUI සත්‍යාපනය සඳහා පරිශීලක නාමය/මුරපදය සකසා නොමැත. කරුණාකර එය පිහිටුවීම සලකා බලන්න.",
+            "body-2": "ඔබට මෙම පරිගණකයේ අනෙකුත් පරිශීලකයින් සමමුහුර්තකරණයට සහ ඒ හරහා ඔබගේ ගොනු වලට ප්‍රවේශ වීම වැලැක්වීමට අවශ්‍ය නම්, සත්‍යාපනය සැකසීම සලකා බලන්න.",
+            "title": "GUI සත්‍යාපනය: පරිශ්‍රීලක හා මුරපදය සකසන්න"
+        },
+        "warning": {
+            "body-1": "මුරපදයක් නොමැතිව දුරස්ථ ප්‍රවේශය සඳහා සමමුහුර්ත කිරීමේ පරිපාලක අතුරුමුහුණත වින්‍යාස කර ඇත.",
+            "body-2": "මෙය හැකර්වරුන්ට ඔබේ පරිගණකයේ ඇති ඕනෑම ගොනුවක් කියවීමට සහ වෙනස් කිරීමට පහසුවෙන් ප්‍රවේශය ලබා දිය හැක.",
+            "body-3": "කරුණාකර සැකසීම් සංවාදයේ GUI සත්‍යාපන පරිශීලකයෙකු සහ මුරපදයක් සකසන්න."
+        }
+    },
     "theme": {
         "name": {
             "black": "කළු",

--- a/gui/default/assets/lang/lang-sk.json
+++ b/gui/default/assets/lang/lang-sk.json
@@ -179,7 +179,6 @@
     "GUI / API HTTPS Certificate": "Certifikát GUI / API HTTPS",
     "GUI Authentication Password": "Prihlasovacie heslo do GUI",
     "GUI Authentication User": "Prihlasovacie meno do GUI",
-    "GUI Authentication: Set User and Password": "Autentifikácia do webového rozhrania: Nastavenie mena a hesla",
     "GUI Listen Address": "Adresa pre prístup do GUI",
     "GUI Override Directory": "Adresár pre GUI Override",
     "GUI Theme": "Grafická téma GUI",
@@ -194,7 +193,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Vaše aktuálne nastavenia naznačujú, že funkciu nechcete povoliť. Automatické hlásenia zlyhaní boli vypnuté.",
     "Identification": "Identifikácia",
     "If untrusted, enter encryption password": "Ak nie je dôveryhodný, uveďte heslo na dešifrovanie",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Ak chcete ostatným používateľom tohto počítača zabrániť v prístupe k službe Syncthing a prostredníctvom nej k vašim súborom, zvážte nastavenie overenia.",
     "Ignore": "Ignorovať",
     "Ignore Patterns": "Ignorované vzory",
     "Ignore Permissions": "Ignorované práva",
@@ -294,7 +292,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Pravidelné skenovanie v danom intervale a neúspešné nastavenie sledovania zmien, opakovanie každú 1 m:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Natrvalo pridať do zoznamu ignorovaných, čím potlačíte ďalšie upozornenia.",
     "Please consult the release notes before performing a major upgrade.": "Pred spustením hlavnej aktualizácie si prosím prečítajte poznámky k vydaniu.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Zadajte prosím prihlasovanie meno a heslo v dialógovom okne nastavení.",
     "Please wait": "Prosím čakajte",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Prefix označujúci, že súbor môže byť odstránený, ak bráni odstráneniu adresára",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Prefix označujúci, že vzory by mali ignorovať veľkosť písma",
@@ -412,7 +409,6 @@
     "Take me back": "Späť",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "Adresa GUI je potlačená možnosťami pri spustení. Kým trvá potlačenie, tu vykonané zmeny sú bez účinku.",
     "The Syncthing Authors": "Autori Syncthing",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Rozhranie správcu Syncthing je nakonfigurované tak, aby umožňovalo vzdialený prístup bez hesla.",
     "The aggregated statistics are publicly available at the URL below.": "Súhrnné štatistiky sú verejne dostupné na uvedenej URL.",
     "The cleanup interval cannot be blank.": "Interval čistenia nemôže byť prázdny.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Konfigurácia bola uložená, ale nebola aktivovaná. Aby sa aktivovala nová konfigurácia, musíte reštartovať Syncthing.",
@@ -452,7 +448,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Automaticky sa zopakujú a po odstránení chyby sa zosynchronizujú.",
     "This Device": "Toto zariadenie",
     "This Month": "Tento mesiac",
-    "This can easily give hackers access to read and change any files on your computer.": "Toto môže jednoducho umožniť hackerom čítať a meniť všetky súbory na vašom počítači.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Toto zariadenie nemôže automaticky objaviť iné zariadenia ani oznámiť svoju vlastnú adresu, aby ju našli ostatní. Pripojiť sa môžu iba zariadenia so staticky nakonfigurovanými adresami.",
     "This is a major version upgrade.": "Toto je hlavná aktualizácia.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Toto nastavenie kontroluje voľné miesto požadované na domovskom disku (napr. indexová databáza).",
@@ -488,7 +483,6 @@
     "Use notifications from the filesystem to detect changed items.": "Na zistenie zmenených položiek použite upozornenia zo súborového systému.",
     "User": "Používateľ",
     "User Home": "Domovský adresár",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Používateľské meno/heslo nebolo nastavené pre overenie GUI. Zvážte jeho nastavenie.",
     "Using a QUIC connection over LAN": "Používam pripojenie QUIC over LAN",
     "Using a QUIC connection over WAN": "Používam pripojenie QUIC over WAN",
     "Using a direct TCP connection over LAN": "Použitie priameho pripojenia TCP cez LAN",
@@ -537,6 +531,18 @@
     "modified": "zmenené",
     "permit": "povolenie",
     "seconds": "sekúnd",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Používateľské meno/heslo nebolo nastavené pre overenie GUI. Zvážte jeho nastavenie.",
+            "body-2": "Ak chcete ostatným používateľom tohto počítača zabrániť v prístupe k službe Syncthing a prostredníctvom nej k vašim súborom, zvážte nastavenie overenia.",
+            "title": "Autentifikácia do webového rozhrania: Nastavenie mena a hesla"
+        },
+        "warning": {
+            "body-1": "Rozhranie správcu Syncthing je nakonfigurované tak, aby umožňovalo vzdialený prístup bez hesla.",
+            "body-2": "Toto môže jednoducho umožniť hackerom čítať a meniť všetky súbory na vašom počítači.",
+            "body-3": "Zadajte prosím prihlasovanie meno a heslo v dialógovom okne nastavení."
+        }
+    },
     "theme": {
         "name": {
             "black": "Čierna",

--- a/gui/default/assets/lang/lang-sl.json
+++ b/gui/default/assets/lang/lang-sl.json
@@ -155,7 +155,6 @@
     "GUI": "Vmesnik",
     "GUI Authentication Password": "Geslo overjanja vmesnika",
     "GUI Authentication User": "Uporabniško ime overjanja vmesnika",
-    "GUI Authentication: Set User and Password": "Overjanje za grafični vmesnik: Nastavi uporabnika in geslo",
     "GUI Listen Address": "Naslov grafičnega vmesnika",
     "GUI Theme": "Slog grafičnega vmesnika",
     "General": "Splošno",
@@ -168,7 +167,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Vendar pa vaše trenutne nastavitve kažejo, da morda ne želite to omogočiti. Za vas smo onemogočili samodejno poročanje o zrušitvah.",
     "Identification": "Identifikacija",
     "If untrusted, enter encryption password": "Če ni zaupanja vreden, vnesite geslo za šifriranje",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Če želite drugim uporabnikom v tem računalniku preprečiti dostop do Syncthinga in prek njega do vaših datotek, razmislite o nastavitvi preverjanja pristnosti.",
     "Ignore": "Prezri",
     "Ignore Patterns": "Vzorec preziranja",
     "Ignore Permissions": "Prezri dovoljenja",
@@ -253,7 +251,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Periodično skeniranje v določenem intervalu in neuspešna nastavitev spremljanje sprememb, ponovni poskus vsake 1 minute:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Trajno ga dodajte na seznam prezrtih, tako da preprečite nadaljnja obvestila.",
     "Please consult the release notes before performing a major upgrade.": "Prosimo, da preverite opombe ob izdaji, preden izvedete nadgradnjo na glavno različico.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Prosimo, nastavite uporabnika in geslo za preverjanje pristnosti grafičnega vmesnika v pozivnem oknu Nastavitve.",
     "Please wait": "Počakajte ...",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Predpona, ki označuje, da je datoteko mogoče izbrisati, če preprečuje odstranitev imenika",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Predpona, ki označuje, da je treba vzorec ujemati brez občutljivosti velikih in malih črk",
@@ -350,7 +347,6 @@
     "Take me back": "Daj me nazaj",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "Naslov grafičnega vmesnika preglasijo možnosti zagona. Spremembe tukaj ne bodo veljale, dokler je preglasitev v veljavi.",
     "The Syncthing Authors": "Syncthing avtorji",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Skrbniški vmesnik Syncthing je konfiguriran tako, da omogoča oddaljeni dostop brez gesla.",
     "The aggregated statistics are publicly available at the URL below.": "Zbrani statistični podatki so javno dostopni na spodnjem URL-ju.",
     "The cleanup interval cannot be blank.": "Interval čiščenja ne sme biti prazen.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Konfiguracija je bila shranjena, vendar ni aktivirana. Sinhronizacija se mora znova zagnati, da aktivirate novo konfiguracijo.",
@@ -385,7 +381,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Samodejno se poskuša znova in bo sinhronizirano, ko je napaka odpravljena.",
     "This Device": "Ta naprava",
     "This Month": "Ta mesec",
-    "This can easily give hackers access to read and change any files on your computer.": "To lahko hekerjem preprosto omogoči dostop do branja in spreminjanja vseh datotek v vašem računalniku.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Ta naprava ne more samodejno odkriti drugih naprav ali objaviti svojega naslova, da ga najdejo drugi. Povezujejo se lahko samo naprave s statično konfiguriranimi naslovi.",
     "This is a major version upgrade.": "To je nadgradnja glavne različice",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Ta nastavitev nadzoruje prosti prostor potreben na domačem (naprimer, indeksirana podatkovna baza) pogonu.",
@@ -416,7 +411,6 @@
     "Usage reporting is always enabled for candidate releases.": "Poročanje o uporabi je vedno omogočeno za kandidatne izdaje.",
     "Use HTTPS for GUI": "Uporabi protokol HTTPS za vmesnik",
     "Use notifications from the filesystem to detect changed items.": "Za odkrivanje spremenjenih elementov uporabite obvestila iz datotečnega sistema.",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Uporabniško ime/geslo ni bilo nastavljeno za preverjanje pristnosti na grafičnem vmesniku. Razmislite o nastavitvi.",
     "Version": "Različica",
     "Versions": "Različice",
     "Versions Path": "Pot do različic",
@@ -455,6 +449,18 @@
     "items": "predmeti",
     "modified": "spremenjeno",
     "seconds": "sekunde",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Uporabniško ime/geslo ni bilo nastavljeno za preverjanje pristnosti na grafičnem vmesniku. Razmislite o nastavitvi.",
+            "body-2": "Če želite drugim uporabnikom v tem računalniku preprečiti dostop do Syncthinga in prek njega do vaših datotek, razmislite o nastavitvi preverjanja pristnosti.",
+            "title": "Overjanje za grafični vmesnik: Nastavi uporabnika in geslo"
+        },
+        "warning": {
+            "body-1": "Skrbniški vmesnik Syncthing je konfiguriran tako, da omogoča oddaljeni dostop brez gesla.",
+            "body-2": "To lahko hekerjem preprosto omogoči dostop do branja in spreminjanja vseh datotek v vašem računalniku.",
+            "body-3": "Prosimo, nastavite uporabnika in geslo za preverjanje pristnosti grafičnega vmesnika v pozivnem oknu Nastavitve."
+        }
+    },
     "theme": {
         "name": {
             "black": "Črna",

--- a/gui/default/assets/lang/lang-sv.json
+++ b/gui/default/assets/lang/lang-sv.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "HTTPS-certifikat för gränssnitt / API",
     "GUI Authentication Password": "Autentiseringslösenord för gränssnitt",
     "GUI Authentication User": "Autentiseringsanvändare för gränssnitt",
-    "GUI Authentication: Set User and Password": "Autentisering för det grafiska gränssnittet: Ställ in användare och lösenord",
     "GUI Listen Address": "Lyssnaradress för gränssnitt",
     "GUI Override Directory": "Åsidosätt mapp för gränssnitt",
     "GUI Theme": "Tema för gränssnitt",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Dina aktuella inställningar indikerar dock att du kanske inte vill att ha det aktiverat. Vi har inaktiverat automatisk kraschrapportering för dig.",
     "Identification": "Identifiering",
     "If untrusted, enter encryption password": "Om opålitlig, ange krypteringslösenord",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Om du vill förhindra att andra användare på denna dator får åtkomst till Syncthing och genom det dina filer, överväg att ställa in autentisering.",
     "Ignore": "Ignorera",
     "Ignore Patterns": "Ignoreringsmönster",
     "Ignore Permissions": "Ignorera rättigheter",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Periodisk skanning vid givet intervall och misslyckades med att ställa in bevakning av ändringar, försöker igen var 1:e minut:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Lägg till det permanent i ignoreringslistan och undertryck ytterligare aviseringar.",
     "Please consult the release notes before performing a major upgrade.": "Läs igenom versionsnyheterna innan du utför en större uppgradering.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Ställ in en autentiseringsanvändare och ett lösenord för det grafiska användargränssnittet i inställningsdialogrutan.",
     "Please wait": "Vänta",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Prefix som indikerar att filen kan tas bort om den förhindrar mappborttagning",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Prefix som indikerar att mönstret ska matchas utan skiftlägeskänslighet",
@@ -415,7 +412,6 @@
     "Take me back": "Ta mig tillbaka",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "Den grafiska gränssnittsadressen åsidosätts av startalternativ. Ändringar här träder inte i kraft så länge åsidosättningen är på plats.",
     "The Syncthing Authors": "Syncthing-upphovsmän",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Administratörsgränssnittet för Syncthing är konfigurerat för att möjliggöra fjärråtkomst utan lösenord.",
     "The aggregated statistics are publicly available at the URL below.": "Den aggregerade statistiken är offentligt tillgänglig på webbadressen nedan.",
     "The cleanup interval cannot be blank.": "Rensningsintervallet kan inte vara tomt.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Konfigurationen har sparats men inte aktiverats. Syncthing måste startas om för att aktivera den nya konfigurationen.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "De omprövas automatiskt och kommer att synkroniseras när felet är löst.",
     "This Device": "Denna enhet",
     "This Month": "Denna månad",
-    "This can easily give hackers access to read and change any files on your computer.": "Detta kan lätt ge hackare tillgång till att läsa och ändra några filer på datorn.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Denna enhet kan inte automatiskt upptäcka andra enheter eller meddela sin egen adress som andra kan hitta. Endast enheter med statiskt konfigurerade adresser kan ansluta.",
     "This is a major version upgrade.": "Det här är en stor uppgradering.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Denna inställning styr hur mycket ledigt utrymme som krävs på hemdisken (dvs. indexdatabasen).",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "Använd aviseringar från filsystemet för att upptäcka ändrade objekt.",
     "User": "Användare",
     "User Home": "Användarhem",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Användarnamn/lösenord har inte ställts in för autentisering av det grafiska gränssnittet. Överväg att ställa in det.",
     "Using a QUIC connection over LAN": "Använder en QUIC-anslutning över LAN",
     "Using a QUIC connection over WAN": "Använder en QUIC-anslutning över WAN",
     "Using a direct TCP connection over LAN": "Använda en direkt TCP-anslutning över LAN",
@@ -540,6 +534,18 @@
     "modified": "ändrad",
     "permit": "tillåt",
     "seconds": "sekunder",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Användarnamn/lösenord har inte ställts in för autentisering av det grafiska gränssnittet. Överväg att ställa in det.",
+            "body-2": "Om du vill förhindra att andra användare på denna dator får åtkomst till Syncthing och genom det dina filer, överväg att ställa in autentisering.",
+            "title": "Autentisering för det grafiska gränssnittet: Ställ in användare och lösenord"
+        },
+        "warning": {
+            "body-1": "Administratörsgränssnittet för Syncthing är konfigurerat för att möjliggöra fjärråtkomst utan lösenord.",
+            "body-2": "Detta kan lätt ge hackare tillgång till att läsa och ändra några filer på datorn.",
+            "body-3": "Ställ in en autentiseringsanvändare och ett lösenord för det grafiska användargränssnittet i inställningsdialogrutan."
+        }
+    },
     "theme": {
         "name": {
             "black": "Svart",

--- a/gui/default/assets/lang/lang-tr.json
+++ b/gui/default/assets/lang/lang-tr.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "GKA / API HTTPS Sertifikası",
     "GUI Authentication Password": "GKA Kimlik Doğrulama Parolası",
     "GUI Authentication User": "GKA Kimlik Doğrulama Kullanıcısı",
-    "GUI Authentication: Set User and Password": "GKA Kimlik Doğrulama: Kullanıcı ve Parola Ayarlayın",
     "GUI Listen Address": "GKA Dinleme Adresi",
     "GUI Override Directory": "GKA Geçersiz Kılma Dizini",
     "GUI Theme": "GKA Teması",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Ancak, şu anki ayarlarınız etkinleştirilmesini istemediğinizi gösterir. Sizin için otomatik çökme bildirmeyi etkisizleştirdik.",
     "Identification": "Kimlik",
     "If untrusted, enter encryption password": "Eğer güvenilmezse, şifreleme parolasını girin",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Eğer bu bilgisayardaki diğer kullanıcıların Syncthing'e ve onun aracılığıyla dosyalarınıza erişmesini önlemek istiyorsanız, kimlik doğrulamasını ayarlamayı düşünün.",
     "Ignore": "Yoksay",
     "Ignore Patterns": "Yoksayma Şekilleri",
     "Ignore Permissions": "İzinleri Yoksay",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Belirli aralıklarla düzenli tarama ve değişiklikleri izlemeyi ayarlama başarısız oldu, her 1 dakikada yeniden deneniyor:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Diğer bildirimleri bastırarak, yoksayma listesine kalıcı olarak ekleyin.",
     "Please consult the release notes before performing a major upgrade.": "Büyük bir yükseltme gerçekleştirmeden önce lütfen yayım notlarına başvurun.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Lütfen Ayarlar ileti öğesinde GKA Kimlik Doğrulama Kullanıcısı ve Parolasını ayarlayın.",
     "Please wait": "Lütfen bekleyin",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Dizin kaldırılmasını önlüyorsa dosyanın silinebileceğini gösteren önek",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Büyük/küçük harf duyarlılığı olmadan şeklin eşleştirilmesi gerektiğini gösteren önek",
@@ -415,7 +412,6 @@
     "Take me back": "Beni geriye götür",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "GKA adresi, başlangıç seçenekleri tarafından geçersiz kılındı. Buradaki değişiklikler, geçersiz kılma yapılırken etkili olmayacak.",
     "The Syncthing Authors": "Syncthing Hazırlayanları",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Syncthing yönetici arayüzü, parola olmadan uzaktan erişime izin verilecek şekilde yapılandırıldı.",
     "The aggregated statistics are publicly available at the URL below.": "Toplanan istatistikler herkese açık olarak aşağıdaki URL'de mevcuttur.",
     "The cleanup interval cannot be blank.": "Temizleme aralığı boş olamaz.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Yapılandırma kaydedildi ancak etkinleştirilmedi. Yeni yapılandırmayı etkinleştirmek için Syncthing yeniden başlatılmak zorunda.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Otomatik olarak yeniden denenirler ve hata çözüldüğünde eşitleneceklerdir.",
     "This Device": "Bu Cihaz",
     "This Month": "Bu Ay",
-    "This can easily give hackers access to read and change any files on your computer.": "Bu, bilgisayar korsanlarının bilgisayarınızdaki herhangi bir dosyayı okumasına ve değiştirmesine kolayca erişim sağlayabilir.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Bu cihaz diğer cihazları otomatik olarak keşfedemez veya başkaları tarafından bulunacak kendi adresini duyuramaz. Yalnızca sabit olarak yapılandırılmış adreslere sahip cihazlar bağlanabilir.",
     "This is a major version upgrade.": "Bu büyük sürüm yükseltmesidir.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Bu ayar, ev (yani indeks veritabanı) diskindeki gereken boş alanı denetler.",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "Değişen öğeleri tespit etmek için dosya sistemi bildirimleri kullanın.",
     "User": "Kullanıcı",
     "User Home": "Kullanıcı Girişi",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Kullanıcı adı/Parola, GKA kimlik doğrulaması için ayarlanmadı. Lütfen ayarlamayı düşünün.",
     "Using a QUIC connection over LAN": "LAN üzerinden QUIC bağlantısı kullanma",
     "Using a QUIC connection over WAN": "WAN üzerinden QUIC bağlantısı kullanma",
     "Using a direct TCP connection over LAN": "LAN üzerinden doğrudan TCP bağlantısı kullanma",
@@ -540,6 +534,18 @@
     "modified": "değiştirildi",
     "permit": "izin ver",
     "seconds": "saniye",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Kullanıcı adı/Parola, GKA kimlik doğrulaması için ayarlanmadı. Lütfen ayarlamayı düşünün.",
+            "body-2": "Eğer bu bilgisayardaki diğer kullanıcıların Syncthing'e ve onun aracılığıyla dosyalarınıza erişmesini önlemek istiyorsanız, kimlik doğrulamasını ayarlamayı düşünün.",
+            "title": "GKA Kimlik Doğrulama: Kullanıcı ve Parola Ayarlayın"
+        },
+        "warning": {
+            "body-1": "Syncthing yönetici arayüzü, parola olmadan uzaktan erişime izin verilecek şekilde yapılandırıldı.",
+            "body-2": "Bu, bilgisayar korsanlarının bilgisayarınızdaki herhangi bir dosyayı okumasına ve değiştirmesine kolayca erişim sağlayabilir.",
+            "body-3": "Lütfen Ayarlar ileti öğesinde GKA Kimlik Doğrulama Kullanıcısı ve Parolasını ayarlayın."
+        }
+    },
     "theme": {
         "name": {
             "black": "Siyah",

--- a/gui/default/assets/lang/lang-uk.json
+++ b/gui/default/assets/lang/lang-uk.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "HTTPS сертифікат для GUI / API",
     "GUI Authentication Password": "Пароль аутентифікації у графічному інтерфейсі",
     "GUI Authentication User": "Користувач аутентифікації у графічному інтерфейсі",
-    "GUI Authentication: Set User and Password": "Доступ до панелі керування: встановіть ім'я користувача та пароль",
     "GUI Listen Address": "Адреса прослуховування для панелі керування",
     "GUI Override Directory": "Перевизначення адреси панелі керування",
     "GUI Theme": "Тема інтерфейсу",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "Однак ваші поточні налаштування вказують, що ви, можливо, не хочете, щоб це було ввімкнено. Ми вимкнули автоматичне повідомлення про аварійне завершення роботи.",
     "Identification": "Ідентифікатор",
     "If untrusted, enter encryption password": "Якщо пристрій ненадійний, введіть пароль для шифрування",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "Якщо ви хочете заборонити іншим користувачам цього комп’ютера отримувати доступ до Syncthing і через нього до своїх файлів, подумайте про налаштування автентифікації.",
     "Ignore": "Ігнорувати",
     "Ignore Patterns": "Шаблони винятків",
     "Ignore Permissions": "Ігнорувати права доступу до файлів",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "Періодичне сканування через визначений інтервал та невдале відстеження змін, повторні спроби кожну 1 хв.:",
     "Permanently add it to the ignore list, suppressing further notifications.": "Додати до чорного списку, щоб ігнорувати подальші сповіщення.",
     "Please consult the release notes before performing a major upgrade.": "Будь ласка, перегляньте примітки до випуску перед мажорним оновленням. ",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Будь ласка, встановіть у налаштуваннях ім'я користувача та пароль до панелі керування.",
     "Please wait": "Будь ласка, зачекайте",
     "Prefix indicating that the file can be deleted if preventing directory removal": "Префікс означає, що файл може бути видалений при запобіганні видаленню директорії",
     "Prefix indicating that the pattern should be matched without case sensitivity": "Префікс означає, що шаблон має збігатися без чутливості до регістру",
@@ -415,7 +412,6 @@
     "Take me back": "Поверніть мене назад",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "Адреса панелі керування користувача перевизначена стартовими налаштуваннями. Зміни зроблені тут не матимуть ефекту доки перевизначення в дії.",
     "The Syncthing Authors": "Автори Syncthing",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Інтерфейс адміністрування Syncthing налаштовано на дозвіл віддаленого доступу без пароля.",
     "The aggregated statistics are publicly available at the URL below.": "Зібрана статистика публічно доступна за наступним посиланням.",
     "The cleanup interval cannot be blank.": "Інтервал очищення не може бути порожнім.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Конфігурацію збережено, але не активовано. Необхідно перезапустити Syncthing для того, щоби активувати нову конфігурацію.",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "Вони будуть автоматично повторно синхронізовані, коли помилку буде усунено. ",
     "This Device": "Локальний пристрій",
     "This Month": "Цього місяця",
-    "This can easily give hackers access to read and change any files on your computer.": "Це легко може дати хакерам доступ на читання та внесення змін до будь-яких файлів на вашому комп'ютері.",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "Цей пристрій не може автоматично виявляти інших або оголошувати свою власну адресу іншим. Підключатися можуть лише пристрої зі статично налаштованими адресами.",
     "This is a major version upgrade.": "Це мажорне оновлення.",
     "This setting controls the free space required on the home (i.e., index database) disk.": "Це налаштування визначає необхідний вільний простір на домашньому (тобто той, що містить базу даних) диску.",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "Використовувати сповіщення від файлової системи для виявлення змінених об'єктів.",
     "User": "Користувач",
     "User Home": "Домашня директорія користувача",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "Логін/пароль не встановлені для автентифікації в панелі керування. Будь ласка, налаштуйте їх.",
     "Using a QUIC connection over LAN": "З використанням QUICK з'єднання у LAN",
     "Using a QUIC connection over WAN": "З використанням QUICK з'єднання у WAN",
     "Using a direct TCP connection over LAN": "Використовується пряме TCP-з'єднання через локальну мережу",
@@ -540,6 +534,18 @@
     "modified": "змінено",
     "permit": "дозволь",
     "seconds": "секунд",
+    "setup-auth": {
+        "notification": {
+            "body-1": "Логін/пароль не встановлені для автентифікації в панелі керування. Будь ласка, налаштуйте їх.",
+            "body-2": "Якщо ви хочете заборонити іншим користувачам цього комп’ютера отримувати доступ до Syncthing і через нього до своїх файлів, подумайте про налаштування автентифікації.",
+            "title": "Доступ до панелі керування: встановіть ім'я користувача та пароль"
+        },
+        "warning": {
+            "body-1": "Інтерфейс адміністрування Syncthing налаштовано на дозвіл віддаленого доступу без пароля.",
+            "body-2": "Це легко може дати хакерам доступ на читання та внесення змін до будь-яких файлів на вашому комп'ютері.",
+            "body-3": "Будь ласка, встановіть у налаштуваннях ім'я користувача та пароль до панелі керування."
+        }
+    },
     "theme": {
         "name": {
             "black": "Чорна",

--- a/gui/default/assets/lang/lang-vi.json
+++ b/gui/default/assets/lang/lang-vi.json
@@ -132,7 +132,6 @@
     "Pause": "Tạm dừng",
     "Paused": "Đã t.dừng",
     "Please consult the release notes before performing a major upgrade.": "Hãy xem kỹ lịch sử phát hành trước khi tiến hành bản cập nhật q.trọng.",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "Hãy thiết lập tên ng.dùng và mật khẩu xác minh GUI trong hộp thoại Cài đặt.",
     "Please wait": "Xin chờ",
     "Preview": "Xem trước",
     "Preview Usage Report": "Xem trước báo cáo s.dụng",
@@ -180,7 +179,6 @@
     "Syncthing is upgrading.": "Syncthing đang n.cấp.",
     "Syncthing seems to be down, or there is a problem with your Internet connection. Retrying…": "Có vẻ như Syncthing đang bị nghẽn hoặc là mạng của bạn có vấn đề. Đang thử lại...",
     "Syncthing seems to be experiencing a problem processing your request. Please refresh the page or restart Syncthing if the problem persists.": "Có vẻ như Syncthing đang gặp phải v.đề khi x.lý yêu cầu của bạn. Xin làm mới trang hoặc kh.động lại Syncthing nếu v.đề vẫn còn tiếp diễn.",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Giao diện q.trị của Syncthing được c.hình nhằm cho phép tr.cập từ xa không cần mật khẩu.",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "Cấu hình đã được lưu nhưng chưa được kích hoạt. Syncthing phải khởi động lại để kích hoạt cấu hình mới. ",
     "The device ID cannot be blank.": "Không được để trống ID thiết bị.",
     "The device ID to enter here can be found in the \"Actions > Show ID\" dialog on the other device. Spaces and dashes are optional (ignored).": "ID thiết bị cần nhập có thể được tìm thấy trong hộp thoại \"Thao tác > Hiển thị ID\" trên thiết bị kia. Khoảng trắng và gạch ngang là tuỳ chọn (bỏ qua).",
@@ -202,7 +200,6 @@
     "The rescan interval must be a non-negative number of seconds.": "Khoảng thời gian quét lại phải là một số giây không âm.",
     "They are retried automatically and will be synced when the error is resolved.": "Chúng sẽ được tự động thử lại và đồng bộ khi lỗi được khắc phục.",
     "This Device": "Thiết bị này",
-    "This can easily give hackers access to read and change any files on your computer.": "Th.tác này có thể khiến tin tặc dễ dàng tr.cập để đọc và th.đổi bất kỳ t.tin nào trên máy của bạn.",
     "This is a major version upgrade.": "Đây là bản nâng cấp quan trọng.",
     "Trash Can File Versioning": "Kiểu thùng rác",
     "Unknown": "Không biết",
@@ -236,6 +233,13 @@
     "files": "Các tệp tin",
     "full documentation": "tài liệu đầy đủ",
     "items": "Các mục",
+    "setup-auth": {
+        "warning": {
+            "body-1": "Giao diện q.trị của Syncthing được c.hình nhằm cho phép tr.cập từ xa không cần mật khẩu.",
+            "body-2": "Th.tác này có thể khiến tin tặc dễ dàng tr.cập để đọc và th.đổi bất kỳ t.tin nào trên máy của bạn.",
+            "body-3": "Hãy thiết lập tên ng.dùng và mật khẩu xác minh GUI trong hộp thoại Cài đặt."
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} muốn chia sẻ thư mục \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} muốn chia sẻ thư mục \"{{folderlabel}}\" \"{{folder}}\"."
 }

--- a/gui/default/assets/lang/lang-zh-CN.json
+++ b/gui/default/assets/lang/lang-zh-CN.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "GUI/API HTTPS 证书",
     "GUI Authentication Password": "GUI 身份验证密码",
     "GUI Authentication User": "GUI 身份验证用户",
-    "GUI Authentication: Set User and Password": "GUI 身份验证：设置用户和密码",
     "GUI Listen Address": "GUI 监听地址",
     "GUI Override Directory": "GUI 覆盖目录",
     "GUI Theme": "GUI 主题",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "我们已经为您禁用了自动发送崩溃报告，因为您当前的设置表明您可能并不想启用该选项。",
     "Identification": "标识",
     "If untrusted, enter encryption password": "如果不受信任，请输入加密密码",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "如果要阻止此计算机上的其他用户访问 Syncthing 并通过它访问文件，请考虑设置身份验证。",
     "Ignore": "忽略",
     "Ignore Patterns": "忽略模式",
     "Ignore Permissions": "忽略权限",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "正在以给定间隔进行定期扫描，但设置更改监视失败，正在每分钟重试一次：",
     "Permanently add it to the ignore list, suppressing further notifications.": "将其永久添加到忽略列表中，以抑制进一步的通知。",
     "Please consult the release notes before performing a major upgrade.": "请在进行重大更新前查看发布说明。",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "请在设置对话框中设置 GUI 身份验证用户和密码。",
     "Please wait": "请稍候",
     "Prefix indicating that the file can be deleted if preventing directory removal": "此前缀表示，如果文件阻止删除目录则文件可被删除",
     "Prefix indicating that the pattern should be matched without case sensitivity": "此前缀表示，后面的模式在匹配时不区分大小写",
@@ -415,7 +412,6 @@
     "Take me back": "返回",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "GUI 地址已被启动选项覆盖。当覆盖存在时，此处的更改就不会生效。",
     "The Syncthing Authors": "Syncthing 作者",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Syncthing 管理界面配置为允许无密码远程访问。",
     "The aggregated statistics are publicly available at the URL below.": "汇总统计可在以下 URL 公开获取。",
     "The cleanup interval cannot be blank.": "清除间隔不能为空。",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "配置已保存但未激活。Syncthing 必须重启才能激活新配置。",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "系统将会自动重试，并在错误解决后同步。",
     "This Device": "此设备",
     "This Month": "本月",
-    "This can easily give hackers access to read and change any files on your computer.": "这会让骇客能够轻而易举地访问及修改您的文件。",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "此设备无法自动发现其他设备，也无法向其他人宣布自己的地址。只有具有静态配置地址的设备才能连接。",
     "This is a major version upgrade.": "这是一次重大版本升级。",
     "This setting controls the free space required on the home (i.e., index database) disk.": "此设置控制主磁盘（即索引数据库）上所需的可用空间。",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "使用来自文件系统的通知来检测更改的项目。",
     "User": "用户",
     "User Home": "用户主目录",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "尚未为 GUI 身份验证设置用户名/密码。请考虑设置。",
     "Using a QUIC connection over LAN": "正在通过局域网使用 QUIC 连接",
     "Using a QUIC connection over WAN": "正在通过广域网使用 QUIC 连接",
     "Using a direct TCP connection over LAN": "正在通过局域网使用直接 TCP 连接",
@@ -540,6 +534,18 @@
     "modified": "已修改",
     "permit": "允许",
     "seconds": "秒",
+    "setup-auth": {
+        "notification": {
+            "body-1": "尚未为 GUI 身份验证设置用户名/密码。请考虑设置。",
+            "body-2": "如果要阻止此计算机上的其他用户访问 Syncthing 并通过它访问文件，请考虑设置身份验证。",
+            "title": "GUI 身份验证：设置用户和密码"
+        },
+        "warning": {
+            "body-1": "Syncthing 管理界面配置为允许无密码远程访问。",
+            "body-2": "这会让骇客能够轻而易举地访问及修改您的文件。",
+            "body-3": "请在设置对话框中设置 GUI 身份验证用户和密码。"
+        }
+    },
     "theme": {
         "name": {
             "black": "黑色",

--- a/gui/default/assets/lang/lang-zh-HK.json
+++ b/gui/default/assets/lang/lang-zh-HK.json
@@ -171,7 +171,6 @@
     "GUI / API HTTPS Certificate": "GUI / API HTTPS 證書",
     "GUI Authentication Password": "圖形管理界面密碼",
     "GUI Authentication User": "圖形管理界面用戶名",
-    "GUI Authentication: Set User and Password": "GUI身份驗證：設置用戶和密碼",
     "GUI Listen Address": "GUI 監聽地址",
     "GUI Override Directory": "GUI 覆蓋目錄",
     "GUI Theme": "GUI 主題",
@@ -185,7 +184,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "我們已經為您關閉了自動崩潰報告發送功能，因為您當前的設置顯示您可能並不想啟用該功能。",
     "Identification": "識別",
     "If untrusted, enter encryption password": "如果不受信任，請輸入加密密碼",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "如果要阻止此計算機上的其他用戶訪問Syncthing並通過它訪問文件，請考慮設置身份驗證。",
     "Ignore": "忽略",
     "Ignore Patterns": "忽略模式",
     "Ignore Permissions": "忽略文件權限",
@@ -273,7 +271,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "正以給定的間隔定期掃瞄但設置更改監視失敗，正在以每 1m 一次重試：",
     "Permanently add it to the ignore list, suppressing further notifications.": "Permanently add it to the ignore list, suppressing further notifications.",
     "Please consult the release notes before performing a major upgrade.": "請在進行重大更新前查看發佈說明。",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "請在設置對話框中設置 GUI 驗證用戶及其密碼。",
     "Please wait": "請稍候",
     "Prefix indicating that the file can be deleted if preventing directory removal": "表示如果刪除了阻止目錄則文件可被刪除的前綴",
     "Prefix indicating that the pattern should be matched without case sensitivity": "此前綴表示，後面的模式在匹配時不區分大小寫",
@@ -385,7 +382,6 @@
     "Take me back": "帶我回去",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "GUI 地址已被啟動選項覆蓋。當覆蓋存在時，此處的更改就不會生效。",
     "The Syncthing Authors": "Syncthing的作者",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "當前配置允許在不使用密碼的情況下遠程訪問 Syncthing 管理界面。",
     "The aggregated statistics are publicly available at the URL below.": "全局統計數據公佈於以下 URL。",
     "The cleanup interval cannot be blank.": "清理間隔不能為空。",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "設置已經保存，但是還未生效。Syncthing 需要重啟以啟用新的設置。",
@@ -423,7 +419,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "系統將會自動重試，當錯誤被解決時，它們將會被同步。",
     "This Device": "當前設備",
     "This Month": "本月",
-    "This can easily give hackers access to read and change any files on your computer.": "這會讓駭客能夠輕而易舉地訪問及修改您的文件。",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "該設備不能自動發現其他設備或宣布自己的地址被其他人發現。只有具有靜態配置地址的設備才能連接。",
     "This is a major version upgrade.": "這是一個重大版本更新。",
     "This setting controls the free space required on the home (i.e., index database) disk.": "此設置控制主（例如索引數據庫）磁盤上需要的可用空間。",
@@ -457,7 +452,6 @@
     "Use HTTPS for GUI": "使用加密連接到圖形管理頁面",
     "Use notifications from the filesystem to detect changed items.": "使用來自文件系統的通知來檢測更改的項目。",
     "User Home": "用戶主頁",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "尚未為GUI身份驗證設置用戶名/密碼。 請考慮進行設置。",
     "Using a direct TCP connection over LAN": "通過內聯網使用直接 TCP 連接",
     "Using a direct TCP connection over WAN": "通過互聯網網使用直接 TCP 連接",
     "Version": "版本",
@@ -497,6 +491,18 @@
     "full documentation": "完整文檔",
     "items": "條目",
     "seconds": "秒",
+    "setup-auth": {
+        "notification": {
+            "body-1": "尚未為GUI身份驗證設置用戶名/密碼。 請考慮進行設置。",
+            "body-2": "如果要阻止此計算機上的其他用戶訪問Syncthing並通過它訪問文件，請考慮設置身份驗證。",
+            "title": "GUI身份驗證：設置用戶和密碼"
+        },
+        "warning": {
+            "body-1": "當前配置允許在不使用密碼的情況下遠程訪問 Syncthing 管理界面。",
+            "body-2": "這會讓駭客能夠輕而易舉地訪問及修改您的文件。",
+            "body-3": "請在設置對話框中設置 GUI 驗證用戶及其密碼。"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} 想將 「{{folder}}」 文件夾共享給您。",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} 想要共享「{{folderlabel}}」（{{folder}}）文件夾給您。",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} 可能會重新引入此設備。"

--- a/gui/default/assets/lang/lang-zh-TW.json
+++ b/gui/default/assets/lang/lang-zh-TW.json
@@ -181,7 +181,6 @@
     "GUI / API HTTPS Certificate": "GUI / API HTTPS 憑證",
     "GUI Authentication Password": "GUI 驗證密碼",
     "GUI Authentication User": "GUI 驗證使用者名稱",
-    "GUI Authentication: Set User and Password": "GUI 驗證：設定使用者名稱與密碼",
     "GUI Listen Address": "GUI 監聽位址",
     "GUI Override Directory": "GUI 覆蓋目錄",
     "GUI Theme": "主題",
@@ -196,7 +195,6 @@
     "However, your current settings indicate you might not want it enabled. We have disabled automatic crash reporting for you.": "但是，當前設定表明您可能不希望啟用它。我們為您停用了當機自動回報。",
     "Identification": "識別碼",
     "If untrusted, enter encryption password": "如未受信任，請輸入加密密碼",
-    "If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.": "如果您想防止在此電腦上的其他使用者存取 Syncthing 及其文件，請考慮設定身份驗證。",
     "Ignore": "忽略",
     "Ignore Patterns": "忽略樣式",
     "Ignore Permissions": "忽略權限",
@@ -296,7 +294,6 @@
     "Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:": "在一定的時間間隔，定期掃描，無法設定觀察變動，每 1 分鐘重試：",
     "Permanently add it to the ignore list, suppressing further notifications.": "永久加入忽略清單，不再進一步通知。",
     "Please consult the release notes before performing a major upgrade.": "執行重大更新前請先參閱版本資訊。",
-    "Please set a GUI Authentication User and Password in the Settings dialog.": "請在設定對話框內設置 GUI 驗證使用者名稱及密碼。",
     "Please wait": "請稍候",
     "Prefix indicating that the file can be deleted if preventing directory removal": "前綴表示當此檔案阻礙了資料夾刪除時，可一併刪除此檔",
     "Prefix indicating that the pattern should be matched without case sensitivity": "前綴表示此樣式不區分大小寫",
@@ -415,7 +412,6 @@
     "Take me back": "帶我回去",
     "The GUI address is overridden by startup options. Changes here will not take effect while the override is in place.": "GUI 位址已被自啟動選項覆寫。當覆寫啟用時，此處變更將不會生效。",
     "The Syncthing Authors": "Syncthing 作者們",
-    "The Syncthing admin interface is configured to allow remote access without a password.": "Syncthing 管理介面被設定允許無密碼的遠端存取。",
     "The aggregated statistics are publicly available at the URL below.": "匯總統計資訊可於下方網址取得。",
     "The cleanup interval cannot be blank.": "清除間隔不能為空白。",
     "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "組態已經儲存但尚未啟用。Syncthing 必須重新啟動以便啟用新的組態。",
@@ -455,7 +451,6 @@
     "They are retried automatically and will be synced when the error is resolved.": "解決問題後，將會自動重試和同步。",
     "This Device": "本機",
     "This Month": "本月",
-    "This can easily give hackers access to read and change any files on your computer.": "這能給駭客輕易的來讀取、變更電腦中的任何檔案。",
     "This device cannot automatically discover other devices or announce its own address to be found by others.  Only devices with statically configured addresses can connect.": "此裝置無法自動尋找其他裝置，或公開自身地址讓其他裝置找到。只有設定了固定位址的裝置才能進行連線。",
     "This is a major version upgrade.": "這是一個重大版本更新。",
     "This setting controls the free space required on the home (i.e., index database) disk.": "此設定控制家目錄（即：索引資料庫）的必須可用空間。",
@@ -491,7 +486,6 @@
     "Use notifications from the filesystem to detect changed items.": "使用來自檔案系統的通知以檢測變動的項目。",
     "User": "使用者",
     "User Home": "使用者主目錄",
-    "Username/Password has not been set for the GUI authentication. Please consider setting it up.": "尚未設定GUI 驗證的使用者名稱/密碼。請考慮進行設定。",
     "Using a QUIC connection over LAN": "通過區域網路使用 QUIC 連線",
     "Using a QUIC connection over WAN": "通過廣域網路使用 QUIC 連線",
     "Using a direct TCP connection over LAN": "通過區域網路使用直接 TCP 連線",
@@ -540,6 +534,18 @@
     "modified": "已修改",
     "permit": "允許",
     "seconds": "秒",
+    "setup-auth": {
+        "notification": {
+            "body-1": "尚未設定GUI 驗證的使用者名稱/密碼。請考慮進行設定。",
+            "body-2": "如果您想防止在此電腦上的其他使用者存取 Syncthing 及其文件，請考慮設定身份驗證。",
+            "title": "GUI 驗證：設定使用者名稱與密碼"
+        },
+        "warning": {
+            "body-1": "Syncthing 管理介面被設定允許無密碼的遠端存取。",
+            "body-2": "這能給駭客輕易的來讀取、變更電腦中的任何檔案。",
+            "body-3": "請在設定對話框內設置 GUI 驗證使用者名稱及密碼。"
+        }
+    },
     "theme": {
         "name": {
             "black": "黑色",

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -152,9 +152,9 @@
             </div>
             <div class="panel-body">
               <p>
-              <span translate>The Syncthing admin interface is configured to allow remote access without a password.</span>
-              <b><span translate>This can easily give hackers access to read and change any files on your computer.</span></b>
-              <span translate>Please set a GUI Authentication User and Password in the Settings dialog.</span>
+              <span translate="setup-auth.warning.body-1">The Syncthing admin interface is configured to allow remote access without a password.</span>
+              <b><span translate="setup-auth.warning.body-2">This can easily give hackers access to read and change any files on your computer.</span></b>
+              <span translate="setup-auth.warning.body-3">Please set a GUI Authentication User and Password in the Settings dialog.</span>
               </p>
             </div>
             <div class="panel-footer">

--- a/gui/default/syncthing/core/notifications.html
+++ b/gui/default/syncthing/core/notifications.html
@@ -120,14 +120,14 @@
 <notification id="authenticationUserAndPassword">
   <div class="panel panel-success">
     <div class="panel-heading">
-      <h3 class="panel-title"><span class="fas fa-bolt"></span>&nbsp;<span translate>GUI Authentication: Set User and Password</span></h3>
+      <h3 class="panel-title"><span class="fas fa-bolt"></span>&nbsp;<span translate="setup-auth.notification.title">GUI Authentication: Set User and Password</span></h3>
     </div>
     <div class="panel-body">
       <p>
-        <span translate>Username/Password has not been set for the GUI authentication. Please consider setting it up.</span>
+        <span translate="setup-auth.notification.body-1">Username/Password has not been set for the GUI authentication. Please consider setting it up.</span>
       </p>
       <p>
-        <span translate>If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.</span>
+        <span translate="setup-auth.notification.body-2">If you want to prevent other users on this computer from accessing Syncthing and through it your files, consider setting up authentication.</span>
       </p>
     </div>
     <div class="panel-footer">


### PR DESCRIPTION
@tomasz1986 @acolomb This is a meta-PR into https://github.com/syncthing/syncthing/pull/9175 to address the translation concerns in https://github.com/syncthing/syncthing/pull/9175#issuecomment-2546534179.

The idea here is to move these translation strings from implicitly using the English text as the translation key, to using an explicit translation key instead. This way the English text can be updated without immediately desyncing the translations - instead they'll continue to use the existing translation string until it's updated to match the new English text.

I've no idea how this would interact with Weblate, but I have tested to make sure the translations do indeed keep working as expected.

With this, the diff from `main` to https://github.com/syncthing/syncthing/pull/9175 for the changed text will be much smaller, but GitHub's UI doesn't show it well in the merge diff. See instead this comparison view for a better reflection of what the diff of the changed text would look like (notice the unchanged translation keys): https://github.com/emlun/syncthing/compare/f751293ccf60f1ac3503678022bc83546aa39d7e...b5e52d51ceb9a7a5f76d617ee3d6f034059c66bd#diff-30599d2b190806fb7a8eea69ba094565427022bfa32d74df117056115c6e25cbR580-R591

I guess a major risk of this would be if any of these translations change on `main` before this gets fully merged through https://github.com/syncthing/syncthing/pull/9175#issuecomment-2546534179. If this is something we indeed want to do, it might be safest to merge https://github.com/emlun/syncthing/commit/f751293ccf60f1ac3503678022bc83546aa39d7e directly into `main` apart from https://github.com/syncthing/syncthing/pull/9175#issuecomment-2546534179.